### PR TITLE
reworked ini/config setting to reduce copy/paste and make the calling simpler

### DIFF
--- a/scriptmodules/emulators/dgen.sh
+++ b/scriptmodules/emulators/dgen.sh
@@ -32,35 +32,37 @@ function configure_dgen()
         chown $user:$user "$configdir/all/dgenrc"
     fi
 
-    ensureKeyValue "joy_pad1_a" "joystick0-button0" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_b" "joystick0-button1" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_c" "joystick0-button2" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_x" "joystick0-button3" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_y" "joystick0-button4" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_z" "joystick0-button5" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_mode" "joystick0-button6" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad1_start" "joystick0-button7" "$configdir/all/dgenrc"
+    iniConfig " = " "" "$configdir/all/dgenrc"
+    iniSet "joy_pad1_a" "joystick0-button0"
+    iniSet "joy_pad1_b" "joystick0-button1"
+    iniSet "joy_pad1_c" "joystick0-button2"
+    iniSet "joy_pad1_x" "joystick0-button3"
+    iniSet "joy_pad1_y" "joystick0-button4"
+    iniSet "joy_pad1_z" "joystick0-button5"
+    iniSet "joy_pad1_mode" "joystick0-button6"
+    iniSet "joy_pad1_start" "joystick0-button7"
 
-    ensureKeyValue "joy_pad2_a" "joystick1-button0" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_b" "joystick1-button1" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_c" "joystick1-button2" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_x" "joystick1-button3" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_y" "joystick1-button4" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_z" "joystick1-button5" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_mode" "joystick1-button6" "$configdir/all/dgenrc"
-    ensureKeyValue "joy_pad2_start" "joystick1-button7" "$configdir/all/dgenrc"
+    iniSet "joy_pad2_a" "joystick1-button0"
+    iniSet "joy_pad2_b" "joystick1-button1"
+    iniSet "joy_pad2_c" "joystick1-button2"
+    iniSet "joy_pad2_x" "joystick1-button3"
+    iniSet "joy_pad2_y" "joystick1-button4"
+    iniSet "joy_pad2_z" "joystick1-button5"
+    iniSet "joy_pad2_mode" "joystick1-button6"
+    iniSet "joy_pad2_start" "joystick1-button7"
 
-    ensureKeyValue "emu_z80_startup" "drz80" "$configdir/all/dgenrc"
-    ensureKeyValue "emu_m68k_startup" "cyclone" "$configdir/all/dgenrc"
+    iniSet "emu_z80_startup" "drz80"
+    iniSet "emu_m68k_startup" "cyclone"
 
     # we don't have opengl (or build dgen with it)
-    ensureKeyValue "bool_opengl" "no" "$configdir/all/dgenrc"
+    iniSet "bool_opengl" "no"
 
     # lower sample rate
-    ensureKeyValue "int_soundrate" "22050" "$configdir/all/dgenrc"
+    iniSet "int_soundrate" "22050"
 
     # if the framebuffer is not the requires resolution dgen seems to give a black screen
-    ensureKeyValueBootconfig "overscan_scale" 1 "/boot/config.txt"
+    iniConfig "=" "" "/boot/config.txt"
+    iniSet "overscan_scale" 1
 
     configure_dispmanx_off_dgen
 
@@ -74,23 +76,25 @@ function configure_dgen()
 }
 
 function configure_dispmanx_off_dgen() {
+    iniConfig " = " "" "$configdir/all/dgenrc"
     # doublebuffer is disabled on framebuffer by default anyway
-    ensureKeyValue "bool_doublebuffer" "no" "$configdir/all/dgenrc"
-    ensureKeyValue "bool_screen_thread" "no" "$configdir/all/dgenrc"
+    iniSet "bool_doublebuffer" "no"
+    iniSet "bool_screen_thread" "no"
     # full screen width/height by default
-    ensureKeyValue "int_width" "-1" "$configdir/all/dgenrc"
-    ensureKeyValue "int_height" "-1" "$configdir/all/dgenrc"
+    iniSet "int_width" "-1"
+    iniSet "int_height" "-1"
     # without dispmanx, scale seems to run the fastest
-    ensureKeyValue "scaling_startup" "scale" "$configdir/all/dgenrc"
+    iniSet "scaling_startup" "scale"
 }
 
 function configure_dispmanx_on_dgen() {
+    iniConfig " = " "" "$configdir/all/dgenrc"
     # turn on double buffer
-    ensureKeyValue "bool_doublebuffer" "yes" "$configdir/all/dgenrc"
-    ensureKeyValue "bool_screen_thread" "yes" "$configdir/all/dgenrc"
+    iniSet "bool_doublebuffer" "yes"
+    iniSet "bool_screen_thread" "yes"
     # set rendering resolution to 320x240
-    ensureKeyValue "int_width" "320" "$configdir/all/dgenrc"
-    ensureKeyValue "int_height" "240" "$configdir/all/dgenrc"
+    iniSet "int_width" "320"
+    iniSet "int_height" "240"
     # no scaling needed
-    ensureKeyValue "scaling_startup" "none" "$configdir/all/dgenrc"
+    iniSet "scaling_startup" "none" "$configdir/all/dgenrc"
 }

--- a/scriptmodules/emulators/dosbox.sh
+++ b/scriptmodules/emulators/dosbox.sh
@@ -37,9 +37,10 @@ _EOF_
     chmod +x "$romdir/pc/Start DOSBox.sh"
 
     local config_path=$(su "$user" -c "\"$md_inst/bin/dosbox\" -printconf")
-    ensureKeyValueShort "usescancodes" "false" "$config_path"
-    ensureKeyValueShort "core" "dynamic" "$config_path"
-    ensureKeyValueShort "cycles" "max" "$config_path"
+    iniConfig "=" "" "$config_path"
+    iniSet "usescancodes" "false"
+    iniSet "core" "dynamic"
+    iniSet "cycles" "max"
 
     configure_dispmanx_off_dosbox
 
@@ -48,12 +49,14 @@ _EOF_
 
 function configure_dispmanx_off_dosbox() {
     local config_path=$("$md_inst/bin/dosbox" -printconf)
+    iniConfig "=" "" "$config_path"
     # scaling
-    ensureKeyValueShort "scaler" "normal2x" "$config_path"
+    iniSet "scaler" "normal2x"
 }
 
 function configure_dispmanx_on_dosbox() {
     local config_path=$("$md_inst/bin/dosbox" -printconf)
+    iniConfig "=" "" "$config_path"
     # no scaling
-    ensureKeyValueShort "scaler" "none" "$config_path"
+    iniSet "scaler" "none"
 }

--- a/scriptmodules/emulators/mame4all.sh
+++ b/scriptmodules/emulators/mame4all.sh
@@ -36,19 +36,21 @@ function configure_mame4all() {
 
     mkdir -p "$configdir/$md_id/"{cfg,hi,inp,memcard,nvram,snap,sta}
     chown -R $user:$user "$configdir/$md_id"
-    ensureKeyValueShort "cfg" "$configdir/$md_id/cfg" "$md_inst/mame.cfg"
-    ensureKeyValueShort "hi" "$configdir/$md_id/hi" "$md_inst/mame.cfg"
-    ensureKeyValueShort "inp" "$configdir/$md_id/inp" "$md_inst/mame.cfg"
-    ensureKeyValueShort "memcard" "$configdir/$md_id/memcard" "$md_inst/mame.cfg"
-    ensureKeyValueShort "nvram" "$configdir/$md_id/nvram" "$md_inst/mame.cfg"
-    ensureKeyValueShort "snap" "$configdir/$md_id/snap" "$md_inst/mame.cfg"
-    ensureKeyValueShort "sta" "$configdir/$md_id/sta" "$md_inst/mame.cfg"
 
-    ensureKeyValueShort "artwork" "$romdir/mame-artwork" "$md_inst/mame.cfg"
-    ensureKeyValueShort "samplepath" "$romdir/mame-samples" "$md_inst/mame.cfg"
-    ensureKeyValueShort "rompath" "$romdir/mame" "$md_inst/mame.cfg"
+    iniConfig "=" "" "$md_inst/mame.cfg"
+    iniSet "cfg" "$configdir/$md_id/cfg"
+    iniSet "hi" "$configdir/$md_id/hi"
+    iniSet "inp" "$configdir/$md_id/inp"
+    iniSet "memcard" "$configdir/$md_id/memcard"
+    iniSet "nvram" "$configdir/$md_id/nvram"
+    iniSet "snap" "$configdir/$md_id/snap"
+    iniSet "sta" "$configdir/$md_id/sta"
 
-    ensureKeyValueShort "samplerate" "22050" "$md_inst/mame.cfg"
+    iniSet "artwork" "$romdir/mame-artwork"
+    iniSet "samplepath" "$romdir/mame-samples"
+    iniSet "rompath" "$romdir/mame"
+
+    iniSet "samplerate" "22050"
 
     setESSystem "MAME" "mame" "~/RetroPie/roms/mame" ".zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$md_inst/mame %BASENAME%\" \"$md_id\"" "arcade" "mame"
 }

--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -76,79 +76,81 @@ function configure_retroarch() {
 
     mkdir -p "$romdir/../BIOS/"
     chown $user:$user "$romdir/../BIOS/"
-    ensureKeyValue "system_directory" "$romdir/../BIOS" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "config_save_on_exit" "false" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "video_aspect_ratio" "1.33" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "video_smooth" "false" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "video_threaded" "true" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "core_options_path" "$configdir/all/retroarch-core-options.cfg" "$configdir/all/retroarch.cfg"
+
+    iniConfig " = " "" "$configdir/all/retroarch.cfg"
+    iniSet "system_directory" "$romdir/../BIOS"
+    iniSet "config_save_on_exit" "false"
+    iniSet "video_aspect_ratio" "1.33"
+    iniSet "video_smooth" "false"
+    iniSet "video_threaded" "true"
+    iniSet "core_options_path" "$configdir/all/retroarch-core-options.cfg"
 
     # enable hotkey ("select" button)
-    ensureKeyValue "input_enable_hotkey" "nul" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_exit_emulator" "escape" "$configdir/all/retroarch.cfg"
+    iniSet "input_enable_hotkey" "nul"
+    iniSet "input_exit_emulator" "escape"
 
     # enable and configure rewind feature
-    ensureKeyValue "rewind_enable" "false" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "rewind_buffer_size" "10" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "rewind_granularity" "2" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_rewind" "r" "$configdir/all/retroarch.cfg"
+    iniSet "rewind_enable" "false"
+    iniSet "rewind_buffer_size" "10"
+    iniSet "rewind_granularity" "2"
+    iniSet "input_rewind" "r"
 
     # enable gpu screenshots
-    ensureKeyValue "video_gpu_screenshot" "true" "$configdir/all/retroarch.cfg"
+    iniSet "video_gpu_screenshot" "true"
 
     # enable and configure shaders
-    ensureKeyValue "input_shader_next" "m" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_shader_prev" "n" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "video_shader_dir" "$md_inst/shader/" "$configdir/all/retroarch.cfg"
+    iniSet "input_shader_next" "m"
+    iniSet "input_shader_prev" "n"
+    iniSet "video_shader_dir" "$md_inst/shader/"
 
     # system-specific shaders, SNES
-    ensureKeyValue "video_shader" "$md_inst/shader/snes_phosphor.glslp" "$configdir/snes/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/snes/retroarch.cfg"
-    ensureKeyValue "video_smooth" "false" "$configdir/snes/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/snes_phosphor.glslp" "$configdir/snes/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/snes/retroarch.cfg"
+    iniSet "video_smooth" "false" "$configdir/snes/retroarch.cfg"
 
     # system-specific shaders, NES
-    ensureKeyValue "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/nes/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/nes/retroarch.cfg"
-    ensureKeyValue "video_smooth" "false" "$configdir/nes/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/nes/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/nes/retroarch.cfg"
+    iniSet "video_smooth" "false" "$configdir/nes/retroarch.cfg"
 
     # system-specific shaders, Megadrive
-    ensureKeyValue "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/megadrive/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/megadrive/retroarch.cfg"
-    ensureKeyValue "video_smooth" "false" "$configdir/megadrive/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/megadrive/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/megadrive/retroarch.cfg"
+    iniSet "video_smooth" "false" "$configdir/megadrive/retroarch.cfg"
 
     # system-specific shaders, Mastersystem
-    ensureKeyValue "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/mastersystem/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/mastersystem/retroarch.cfg"
-    ensureKeyValue "video_smooth" "false" "$configdir/mastersystem/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/phosphor.glslp" "$configdir/mastersystem/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/mastersystem/retroarch.cfg"
+    iniSet "video_smooth" "false" "$configdir/mastersystem/retroarch.cfg"
 
     # system-specific shaders, Gameboy
-    ensureKeyValue "video_shader" "$md_inst/shader/hq4x.glslp" "$configdir/gb/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/gb/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/hq4x.glslp" "$configdir/gb/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/gb/retroarch.cfg"
 
     # system-specific shaders, Gameboy Color
-    ensureKeyValue "video_shader" "$md_inst/shader/hq4x.glslp" "$configdir/gbc/retroarch.cfg"
-    ensureKeyValue "video_shader_enable" "false" "$configdir/gbc/retroarch.cfg"
+    iniSet "video_shader" "$md_inst/shader/hq4x.glslp" "$configdir/gbc/retroarch.cfg"
+    iniSet "video_shader_enable" "false" "$configdir/gbc/retroarch.cfg"
 
     # system-specific, PSX
-    ensureKeyValue "rewind_enable" "false" "$configdir/psx/retroarch.cfg"
+    iniSet "rewind_enable" "false" "$configdir/psx/retroarch.cfg"
 
     # configure keyboard mappings
-    ensureKeyValue "input_player1_a" "x" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_b" "z" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_y" "a" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_x" "s" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_start" "enter" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_select" "rshift" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_l" "q" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_r" "w" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_left" "left" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_right" "right" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_up" "up" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "input_player1_down" "down" "$configdir/all/retroarch.cfg"
+    iniSet "input_player1_a" "x"
+    iniSet "input_player1_b" "z"
+    iniSet "input_player1_y" "a"
+    iniSet "input_player1_x" "s"
+    iniSet "input_player1_start" "enter"
+    iniSet "input_player1_select" "rshift"
+    iniSet "input_player1_l" "q"
+    iniSet "input_player1_r" "w"
+    iniSet "input_player1_left" "left"
+    iniSet "input_player1_right" "right"
+    iniSet "input_player1_up" "up"
+    iniSet "input_player1_down" "down"
 
     # input settings
-    ensureKeyValue "input_autodetect_enable" "true" "$configdir/all/retroarch.cfg"
-    ensureKeyValue "joypad_autoconfig_dir" "$md_inst/configs/" "$configdir/all/retroarch.cfg"
+    iniSet "input_autodetect_enable" "true"
+    iniSet "joypad_autoconfig_dir" "$md_inst/configs/"
 
     chown $user:$user -R "$configdir"
 }

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -25,6 +25,18 @@
 #  Many, many thanks go to all people that provide the individual packages!!!
 #
 
+function printMsg()
+{
+    echo -e "\n= = = = = = = = = = = = = = = = = = = = =\n$1\n= = = = = = = = = = = = = = = = = = = = =\n"
+}
+
+function fatalError()
+{
+    printMsg "Fatal Error"
+    echo "$1"
+    exit 1
+}
+
 function ask()
 {
     echo -e -n "$@" '[y/n] ' ; read ans
@@ -44,15 +56,27 @@ function addLineToFile()
     echo "Added $1 to file $2"
 }
 
-# arg 1: set/unset, arg 2: delimiter, arg 3: quote character, arg 4: key, arg 5: value, arg 6: file
-function iniSet()
+# arg 1: set/unset, arg 2: delimiter, arg 3: quote character
+function iniConfig()
 {
-    local command="$1"
-    local delim="$2"
-    local quote="$3"
-    local key="$4"
-    local value="$5"
-    local file="$6"
+    __ini_cfg_delim="$1"
+    __ini_cfg_quote="$2"
+    __ini_cfg_file="$3"
+}
+
+# arg 1: command, arg 2: key, arg 2: value, arg 3: file (optional - uses file from iniConfig if not used)
+function iniProcess()
+{
+    local cmd="$1"
+    local key="$2"
+    local value="$3"
+    local file="$4"
+    [ "$file" == "" ] && file="$__ini_cfg_file"
+    local delim="$__ini_cfg_delim"
+    local quote="$__ini_cfg_quote"
+
+    [ "$file" == "" ] && fatalError "No file provided for ini/config change"
+    [ "$key" == "" ] && fatalError "No key provided for ini/config change on $file"
 
     local delim_strip=${delim// /}
     local match_re="[\s#]*$key\s*$delim_strip.*$"
@@ -64,7 +88,7 @@ function iniSet()
         touch "$file"
     fi
 
-    [ "$command" == "unset" ] && key="# $key"
+    [ "$cmd" == "unset" ] && key="# $key"
     local replace="$key$delim$quote$value$quote"
     echo "Setting $replace in $file"
     if [[ -z "$match" ]]; then
@@ -76,45 +100,16 @@ function iniSet()
     fi
 }
 
-# arg 1: key, arg 2: value, arg 3: file
-# make sure that a key-value pair is set in file
-# key = value
-function ensureKeyValue()
+# arg 1: key, arg 2: value, arg 3: file (optional - uses file from iniConfig if not used)
+function iniUnset()
 {
-    iniSet "set" " = " "" "$1" "$2" "$3"
+    iniProcess "unset" "$1" "$2" "$3"
 }
 
-# make sure that a key-value pair is NOT set in file
-# # key = value
-function disableKeyValue()
+# arg 1: key, arg 2: value, arg 3: file (optional - uses file from iniConfig if not used)
+function iniSet()
 {
-    iniSet "unset" " = " "" "$1" "$2" "$3"
-}
-
-# arg 1: key, arg 2: value, arg 3: file
-# make sure that a key-value pair is set in file
-# key=value
-function ensureKeyValueShort()
-{
-    iniSet "set" "=" "" "$1" "$2" "$3"
-}
-
-# make sure that a key-value pair is NOT set in file
-# # key=value
-function disableKeyValueShort()
-{
-    iniSet "unset" "=" "" "$1" "$2" "$3"
-}
-
-# ensures pair of key ($1)-value ($2) in file $3
-function ensureKeyValueBootconfig()
-{
-    iniSet "set" "=" "" "$1" "$2" "$3"
-}
-
-function printMsg()
-{
-    echo -e "\n= = = = = = = = = = = = = = = = = = = = =\n$1\n= = = = = = = = = = = = = = = = = = = = =\n"
+    iniProcess "set" "$1" "$2" "$3"
 }
 
 function checkForInstalledAPTPackage()

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -56,7 +56,7 @@ function addLineToFile()
     echo "Added $1 to file $2"
 }
 
-# arg 1: set/unset, arg 2: delimiter, arg 3: quote character
+# arg 1: delimiter, arg 2: quote, arg 3: file
 function iniConfig()
 {
     __ini_cfg_delim="$1"

--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -28,9 +28,10 @@ function configure_mupen64plus() {
     ensureSystemretroconfig "n64"
 
     # Set core options
-    ensureKeyValue "mupen64-gfxplugin" "rice" "$configdir/all/retroarch-core-options.cfg"
-    ensureKeyValue "mupen64-gfxplugin-accuracy" "low" "$configdir/all/retroarch-core-options.cfg"
-    ensureKeyValue "mupen64-screensize" "640x480" "$configdir/all/retroarch-core-options.cfg"
+    iniConfig " = " "" "$configdir/all/retroarch-core-options.cfg"
+    iniSet "mupen64-gfxplugin" "rice"
+    iniSet "mupen64-gfxplugin-accuracy" "low"
+    iniSet "mupen64-screensize" "640x480"
 
     # Copy config files
     cp "$md_inst/data/"{mupen64plus.cht,mupencheat.txt,mupen64plus.ini,font.ttf} "$home/RetroPie/BIOS/"

--- a/scriptmodules/supplementary/dispmanx.sh
+++ b/scriptmodules/supplementary/dispmanx.sh
@@ -3,6 +3,8 @@ rp_module_desc="Configure emulators to use dispmanx SDL"
 rp_module_menus="3+"
 
 function configure_dispmanx() {
+    iniConfig "=" "" "$configdir/all/dispmanx.cfg"
+
     while true; do
         local count=1
         local options=()
@@ -28,9 +30,9 @@ function configure_dispmanx() {
         if [ "$choice" != "" ]; then
             local params=(${command[$choice]})
             if [ "${params[1]}" = "on" ]; then
-                ensureKeyValueShort "${params[0]}" "1" "$configdir/all/dispmanx.cfg"
+                iniSet "${params[0]}" "1"
             else
-                ensureKeyValueShort "${params[0]}" "0" "$configdir/all/dispmanx.cfg"
+                iniSet "${params[0]}" "0"
             fi
             rp_callModule "${params[0]}" configure_dispmanx_${params[1]}
         else

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -52,9 +52,10 @@ _EOF_
     chmod +x /usr/bin/emulationstation
 
     # make sure that ES has enough GPU memory
-    ensureKeyValueBootconfig "gpu_mem_256" 128 "/boot/config.txt"
-    ensureKeyValueBootconfig "gpu_mem_512" 256 "/boot/config.txt"
-    ensureKeyValueBootconfig "overscan_scale" 1 "/boot/config.txt"
+    iniConfig "=" "" /boot/config.txt
+    iniSet "gpu_mem_256" 128
+    iniSet "gpu_mem_512" 256
+    iniSet "overscan_scale" 1
 
     if [[ $__netplayenable == "E" ]]; then
          local __tmpnetplaymode="-$__netplaymode "

--- a/scriptmodules/supplementary/gamecondriver.sh
+++ b/scriptmodules/supplementary/gamecondriver.sh
@@ -117,41 +117,43 @@ __________\n\
         --yesno "Would you like to update button mappings \
     to $configdir/all/retroarch.cfg ?" 22 76
 
+    iniConfig " = " "" "$configdir/all/retroarch.cfg"
+
       case $? in
        0)
         if [ $GPIOREV = 1 ]; then
-                ensureKeyValue "input_player1_joypad_index" "0" "$configdir/all/retroarch.cfg"
-                ensureKeyValue "input_player2_joypad_index" "1" "$configdir/all/retroarch.cfg"
+                iniSet "input_player1_joypad_index" "0"
+                iniSet "input_player2_joypad_index" "1"
         else
-            ensureKeyValue "input_player1_joypad_index" "1" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_joypad_index" "0" "$configdir/all/retroarch.cfg"
+            iniSet "input_player1_joypad_index" "1"
+            iniSet "input_player2_joypad_index" "0"
         fi
 
-            ensureKeyValue "input_player1_a_btn" "0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_b_btn" "1" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_x_btn" "2" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_y_btn" "3" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_l_btn" "4" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_r_btn" "5" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_start_btn" "7" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_select_btn" "6" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_left_axis" "-0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_up_axis" "-1" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_right_axis" "+0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player1_down_axis" "+1" "$configdir/all/retroarch.cfg"
+            iniSet "input_player1_a_btn" "0"
+            iniSet "input_player1_b_btn" "1"
+            iniSet "input_player1_x_btn" "2"
+            iniSet "input_player1_y_btn" "3"
+            iniSet "input_player1_l_btn" "4"
+            iniSet "input_player1_r_btn" "5"
+            iniSet "input_player1_start_btn" "7"
+            iniSet "input_player1_select_btn" "6"
+            iniSet "input_player1_left_axis" "-0"
+            iniSet "input_player1_up_axis" "-1"
+            iniSet "input_player1_right_axis" "+0"
+            iniSet "input_player1_down_axis" "+1"
 
-            ensureKeyValue "input_player2_a_btn" "0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_b_btn" "1" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_x_btn" "2" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_y_btn" "3" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_l_btn" "4" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_r_btn" "5" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_start_btn" "7" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_select_btn" "6" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_left_axis" "-0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_up_axis" "-1" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_right_axis" "+0" "$configdir/all/retroarch.cfg"
-            ensureKeyValue "input_player2_down_axis" "+1" "$configdir/all/retroarch.cfg"
+            iniSet "input_player2_a_btn" "0"
+            iniSet "input_player2_b_btn" "1"
+            iniSet "input_player2_x_btn" "2"
+            iniSet "input_player2_y_btn" "3"
+            iniSet "input_player2_l_btn" "4"
+            iniSet "input_player2_r_btn" "5"
+            iniSet "input_player2_start_btn" "7"
+            iniSet "input_player2_select_btn" "6"
+            iniSet "input_player2_left_axis" "-0"
+            iniSet "input_player2_up_axis" "-1"
+            iniSet "input_player2_right_axis" "+0"
+            iniSet "input_player2_down_axis" "+1"
         ;;
        *)
         ;;

--- a/scriptmodules/supplementary/hotkey.sh
+++ b/scriptmodules/supplementary/hotkey.sh
@@ -3,6 +3,7 @@ rp_module_desc="Change hotkey behaviour"
 rp_module_menus="3+"
 
 function configure_hotkey() {
+    iniConfig " = " "" "$configdir/all/retroarch.cfg"
     cmd=(dialog --backtitle "$__backtitle" --menu "Choose the desired hotkey behaviour." 22 76 16)
     options=(1 "Hotkeys enabled. (default)"
              2 "Press ALT to enable hotkeys."
@@ -10,17 +11,17 @@ function configure_hotkey() {
     choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
     if [ "$choices" != "" ]; then
         case $choices in
-            1) ensureKeyValue "input_enable_hotkey" "nul" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_exit_emulator" "escape" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_menu_toggle" "F1" "$configdir/all/retroarch.cfg"
+            1) iniSet "input_enable_hotkey" "nul"
+               iniSet "input_exit_emulator" "escape"
+               iniSet "input_menu_toggle" "F1"
                             ;;
-            2) ensureKeyValue "input_enable_hotkey" "alt" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_exit_emulator" "escape" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_menu_toggle" "F1" "$configdir/all/retroarch.cfg"
+            2) iniSet "input_enable_hotkey" "alt"
+               iniSet "input_exit_emulator" "escape"
+               iniSet "input_menu_toggle" "F1"
                             ;;
-            3) ensureKeyValue "input_enable_hotkey" "escape" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_exit_emulator" "nul" "$configdir/all/retroarch.cfg"
-               ensureKeyValue "input_menu_toggle" "escape" "$configdir/all/retroarch.cfg"
+            3) iniSet "input_enable_hotkey" "escape"
+               iniSet "input_exit_emulator" "nul"
+               iniSet "input_menu_toggle" "escape"
                             ;;
         esac
     else

--- a/scriptmodules/supplementary/setavoidsafemode.sh
+++ b/scriptmodules/supplementary/setavoidsafemode.sh
@@ -3,5 +3,6 @@ rp_module_desc="Set avoid_safe_mode"
 rp_module_menus="2+"
 
 function install_setavoidsafemode() {
-    ensureKeyValueBootconfig "avoid_safe_mode" 1 "/boot/config.txt"
+    iniConfig "=" "" "/boot/config.txt"
+    iniSet "avoid_safe_mode" 1
 }

--- a/scriptmodules/supplementary/snesdev.sh
+++ b/scriptmodules/supplementary/snesdev.sh
@@ -36,24 +36,25 @@ function sup_checkInstallSNESDev() {
 
 # start SNESDev on boot and configure RetroArch input settings
 function sup_enableSNESDevAtStart() {
+    iniConfig "=" "" "/etc/snesdev.cfg"
     clear
     printMsg "Enabling SNESDev on boot."
 
     case $1 in
       1)
-        ensureKeyValueBootconfig "button_enabled" "0" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad1_enabled" "1" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad2_enabled" "1" "/etc/snesdev.cfg"
+        iniSet "button_enabled" "0" 
+        iniSet "gamepad1_enabled" "1"
+        iniSet "gamepad2_enabled" "1"
         ;;
       2)
-        ensureKeyValueBootconfig "button_enabled" "1" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad1_enabled" "0" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad2_enabled" "0" "/etc/snesdev.cfg"
+        iniSet "button_enabled" "1"
+        iniSet "gamepad1_enabled" "0"
+        iniSet "gamepad2_enabled" "0"
         ;;
       3)
-        ensureKeyValueBootconfig "button_enabled" "1" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad1_enabled" "1" "/etc/snesdev.cfg"
-        ensureKeyValueBootconfig "gamepad2_enabled" "1" "/etc/snesdev.cfg"
+        iniSet "button_enabled" "1"
+        iniSet "gamepad1_enabled" "1"
+        iniSet "gamepad2_enabled" "1"
         ;;
       *)
         echo "[sup_enableSNESDevAtStart] I do not understand what is going on here."
@@ -63,12 +64,13 @@ function sup_enableSNESDevAtStart() {
 }
 
 function sup_snesdevAdapterversion() {
+  iniConfig "=" "" "/etc/snesdev.cfg"
   if [[ $1 -eq 1 ]]; then
-    ensureKeyValueBootconfig "adapter_version" "1x" "/etc/snesdev.cfg"
+    iniSet "adapter_version" "1x"
   elif [[ $1 -eq 2 ]]; then
-    ensureKeyValueBootconfig "adapter_version" "2x" "/etc/snesdev.cfg"
+    iniSet "adapter_version" "2x"
   else
-    ensureKeyValueBootconfig "adapter_version" "2x" "/etc/snesdev.cfg"
+    iniSet "adapter_version" "2x"
   fi
 }
 

--- a/scriptmodules/supplementary/xboxdrv.sh
+++ b/scriptmodules/supplementary/xboxdrv.sh
@@ -7,6 +7,7 @@ function install_xboxdrv() {
     if [[ -z `cat /etc/rc.local | grep "xboxdrv"` ]]; then
         sed -i -e '13,$ s|exit 0|xboxdrv --daemon --id 0 --led 2 --deadzone 4000 --silent --trigger-as-button --next-controller --id 1 --led 3 --deadzone 4000 --silent --trigger-as-button --dbus disabled --detach-kernel-driver \&\nexit 0|g' /etc/rc.local
     fi
-    ensureKeyValueBootconfig "dwc_otg.speed" "1" "/boot/config.txt"
+    iniConfig "=" "" "/boot/config.txt"
+    iniSet "dwc_otg.speed" "1"
     dialog --backtitle "$__backtitle" --msgbox "Installed xboxdrv and adapted /etc/rc.local. It will be started on boot." 22 76
 }


### PR DESCRIPTION
Since the most common usage is to change a few configuration values at once, we now have a iniConfig function that sets up the delimiter type (such as "=" or " = "), the value quote character (often "" nothing or "\"" a single quote) and the filename. you can then just call "iniSet" or "iniUnset" with two parameters for key and value. A third parameter can be used in case you wish to use the current ini settings but on a different file. We should now easily be able to handle any key/value configs whilst keeping the code simple/compact