### PR TITLE
switch scummvm to build from source

### DIFF
--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -22,7 +22,7 @@ function build_scummvm() {
 function install_scummvm() {
     make install
     mkdir -p "$md_inst/extra"
-    cp -v "backends/vkeybd/packs/"vkeybd_*.zip "$md_inst/extra"
+    cp -v backends/vkeybd/packs/vkeybd_*.zip "$md_inst/extra"
 }
 
 function configure_scummvm() {

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -21,7 +21,8 @@ function build_scummvm() {
 
 function install_scummvm() {
     make install
-    cp -v "backends/vkeybd/packs/"vkeybd_*.zip "$md_inst/share/scummvm/"
+    mkdir -p "$md_inst/extra"
+    cp -v "backends/vkeybd/packs/"vkeybd_*.zip "$md_inst/extra"
 }
 
 function configure_scummvm() {
@@ -32,7 +33,7 @@ function configure_scummvm() {
 #!/bin/bash
 game="\$1"
 [[ "\$game" =~ ^\+ ]] && game=""
-$md_inst/bin/scummvm --joystick=0 \$game
+$md_inst/bin/scummvm --joystick=0 --extrapath="$md_inst/extra" \$game
 while read line; do
     id=(\$line);
     touch "$romdir/scummvm/\$id.svm"

--- a/scriptmodules/emulators/scummvm.sh
+++ b/scriptmodules/emulators/scummvm.sh
@@ -3,17 +3,43 @@ rp_module_desc="ScummVM"
 rp_module_menus="2+"
 rp_module_flags="dispmanx"
 
+function depends_scummvm() {
+    checkNeededPackages libsdl1.2-dev libjpeg8-dev libmpeg2-4-dev libogg-dev libvorbis-dev libflac-dev libmad0-dev libpng12-dev libtheora-dev libfaad-dev libfluidsynth-dev libfreetype6-dev zlib1g-dev
+}
+
+function sources_scummvm() {
+    wget -O- -q http://downloads.petrockblock.com/retropiearchives/scummvm-1.7.0.tar.gz | tar -xvz --strip-components=1
+}
+
+function build_scummvm() {
+    ./configure --enable-vkeybd --enable-release --disable-debug --enable-keymapper --disable-eventrecorder --prefix="$md_inst"
+    make clean
+    make
+    strip "$md_build/scummvm"
+    md_ret_require="$md_build/scummvm"
+}
+
 function install_scummvm() {
-    aptInstall scummvm scummvm-data
-    if [[ $? -gt 0 ]]; then
-        __ERRMSGS="$__ERRMSGS Could not successfully install ScummVM."
-    else
-        __INFMSGS="$__INFMSGS ScummVM has successfully been installed. You can start the ScummVM GUI by typing 'scummvm' in the console. Copy your Scumm games into the directory '$rootdir/roms/scummvm'. When you get a blank screen after running scumm for the first time, press CTRL-q. You should not get a blank screen with further runs of scummvm."
-    fi
+    make install
+    cp -v "backends/vkeybd/packs/"vkeybd_*.zip "$md_inst/share/scummvm/"
 }
 
 function configure_scummvm() {
     mkRomDir "scummvm"
 
-    setESSystem "ScummVM" "scummvm" "~/RetroPie/roms/scummvm" ".exe .EXE" "$rootdir/supplementary/runcommand/runcommand.sh 0 \"scummvm\" \"$md_id\"" "pc" "scummvm"
+    # Create startup script
+    cat > "$romdir/scummvm/+Launch GUI.sh" << _EOF_
+#!/bin/bash
+game="\$1"
+[[ "\$game" =~ ^\+ ]] && game=""
+$md_inst/bin/scummvm --joystick=0 \$game
+while read line; do
+    id=(\$line);
+    touch "$romdir/scummvm/\$id.svm"
+done < <($md_inst/bin/scummvm --list-targets | tail -n +3)
+_EOF_
+    chown $user:$user "$romdir/scummvm/+Launch GUI.sh"
+    chmod u+x "$romdir/scummvm/+Launch GUI.sh"
+
+    setESSystem "ScummVM" "scummvm" "~/RetroPie/roms/scummvm" ".sh .svm" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$romdir/scummvm/+Launch\ GUI.sh %BASENAME%\" \"$md_id\"" "pc" "scummvm"
 }

--- a/scriptmodules/retropiesetup.sh
+++ b/scriptmodules/retropiesetup.sh
@@ -158,7 +158,6 @@ function rps_main_binaries()
         rp_callModule retroarchautoconf
 
         rp_callModule stella
-        rp_callModule scummvm
         rp_callModule zmachine
         rp_callModule fuse
         rp_callModule hatari


### PR DESCRIPTION
enabling:
 * virtual / on screen keyboard
 * keymapper gui for mapping keyboard etc
 * newer build than debian repository (1.7.0)

rework the scummvm emulationstation config. we launch it from a script now (in roms/scummvm/) that will show up in emulation station too (and act
as a option to launch scummvm gui). Once launched, games can be added to scummvm. on exit, these are then added as files to rom/scummvm with the game id
as the name (.svm) which then show up in emulation station. this makes adding/launching games automatic.

idea for launching came from http://blog.petrockblock.com/forums/topic/guidescript-add-all-your-scummvm-games-to-emulationstation/#post-4814