### PR TITLE
Add userland.sh

### DIFF
--- a/scriptmodules/supplementary/userland.sh
+++ b/scriptmodules/supplementary/userland.sh
@@ -1,0 +1,21 @@
+# If threaded_video runs slower or audio stutters after rpi-update rebuild userland libs.
+# Retroarch seems to run slower with prebuild libs.
+rp_module_id="userland"
+rp_module_desc="Raspbian userland libs"
+rp_module_menus="4+"
+
+function depends_userland() {
+	checkNeededPackages gcc-4.8 g++-4.8
+}
+
+function sources_userland() {
+    gitPullOrClone "$md_build" "https://github.com/raspberrypi/userland" NS
+    sed -i 's/-mcpu=arm1176jzf-s/-march=armv6j/g' /userland/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
+}
+
+function build_userland() {
+    gcc_version 4.8
+    ./buildme
+    gcc_version $__default_gcc_version
+    sync
+}

--- a/scriptmodules/supplementary/userland.sh
+++ b/scriptmodules/supplementary/userland.sh
@@ -10,12 +10,9 @@ function depends_userland() {
 
 function sources_userland() {
     gitPullOrClone "$md_build" "https://github.com/raspberrypi/userland" NS
-    sed -i 's/-mcpu=arm1176jzf-s/-march=armv6j/g' /userland/makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
+    sed -i 's/-mcpu=arm1176jzf-s/-march=armv6j/g' /makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake
 }
 
 function build_userland() {
-    gcc_version 4.8
-    ./buildme
-    gcc_version $__default_gcc_version
-    sync
+    ./buildme CC="gcc-4.8" CXX="g++-4.8"
 }


### PR DESCRIPTION
If threaded_video runs slower or audio stutters after rpi-update rebuild userland libs with this script.

It is some kind of hocus pocus script, because i have the impression self build userland libs run better. There is a CFLAG difference between cross compiled and nativ compiled builds. A native build uses add_definitions("-mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard"). A cross compiled build uses ADD_DEFINITIONS("-march=armv6").