### PR TITLE
Retronet

### DIFF
--- a/configs/retronetplay.cfg
+++ b/configs/retronetplay.cfg
@@ -1,6 +1,0 @@
-__netplayenable="D"
-__netplaymode="H"
-__netplayport="55435"
-__netplayhostip="192.168.0.1"
-__netplayhostip_cfile=""
-__netplayframes="15"

--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -66,8 +66,6 @@ mkRootRomDir "$romdir"
 
 rp_registerAllModules
 
-retronetLoadConfig
-
 [[ "$1" == "init" ]] && return
 
 # ID scriptmode

--- a/retropie_packages.sh
+++ b/retropie_packages.sh
@@ -66,10 +66,9 @@ mkRootRomDir "$romdir"
 
 rp_registerAllModules
 
-[[ "$1" == "init" ]] && return
+retronetLoadConfig
 
-# load RetronetPlay configuration
-source "$scriptdir/configs/retronetplay.cfg"
+[[ "$1" == "init" ]] && return
 
 # ID scriptmode
 if [[ $# -eq 1 ]]; then

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -274,28 +274,6 @@ function mkUserDir() {
     chown $user:$user "$1"
 }
 
-function retronetParams() {
-    if [[ "$__netplayenable" == "E" ]]; then
-        __retronet_params="-$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes"
-    else
-        __retronet_params=""
-    fi
-}
-
-function retronetLoadConfig() {
-    if [[ -f "$rootdir/configs/all/retronetplay.cfg" ]]; then
-        source "$rootdir/configs/all/retronetplay.cfg"
-    else
-        __netplayenable="D"
-        __netplaymode="H"
-        __netplayport="55435"
-        __netplayhostip="192.168.0.1"
-        __netplayhostip_cfile=""
-        __netplayframes="15"
-    fi
-    retronetParams
-}
-
 function updateESConfigEdit() {
     gitPullOrClone "$rootdir/supplementary/ESConfigEdit" git://github.com/petrockblog/ESConfigEdit
 }

--- a/scriptmodules/helpers.sh
+++ b/scriptmodules/helpers.sh
@@ -274,6 +274,28 @@ function mkUserDir() {
     chown $user:$user "$1"
 }
 
+function retronetParams() {
+    if [[ "$__netplayenable" == "E" ]]; then
+        __retronet_params="-$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes"
+    else
+        __retronet_params=""
+    fi
+}
+
+function retronetLoadConfig() {
+    if [[ -f "$rootdir/configs/all/retronetplay.cfg" ]]; then
+        source "$rootdir/configs/all/retronetplay.cfg"
+    else
+        __netplayenable="D"
+        __netplaymode="H"
+        __netplayport="55435"
+        __netplayhostip="192.168.0.1"
+        __netplayhostip_cfile=""
+        __netplayframes="15"
+    fi
+    retronetParams
+}
+
 function updateESConfigEdit() {
     gitPullOrClone "$rootdir/supplementary/ESConfigEdit" git://github.com/petrockblog/ESConfigEdit
 }

--- a/scriptmodules/libretrocores/armsnes.sh
+++ b/scriptmodules/libretrocores/armsnes.sh
@@ -22,8 +22,7 @@ function install_armsnes() {
 function configure_armsnes() {
     mkdir -p $romdir/snes
 
-    rps_retronet_prepareConfig
-    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libpocketsnes.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile $__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "snes" "snes"
+    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libpocketsnes.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "snes" "snes"
     # <!-- alternatively: <command>$emudir/snes9x-rpi/snes9x %ROM%</command> -->
     # <!-- alternatively: <command>$emudir/pisnes/snes9x %ROM%</command> -->
 }

--- a/scriptmodules/libretrocores/armsnes.sh
+++ b/scriptmodules/libretrocores/armsnes.sh
@@ -22,7 +22,7 @@ function install_armsnes() {
 function configure_armsnes() {
     mkdir -p $romdir/snes
 
-    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libpocketsnes.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "snes" "snes"
+    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libpocketsnes.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg %ROM%\" \"$md_id\"" "snes" "snes"
     # <!-- alternatively: <command>$emudir/snes9x-rpi/snes9x %ROM%</command> -->
     # <!-- alternatively: <command>$emudir/pisnes/snes9x %ROM%</command> -->
 }

--- a/scriptmodules/libretrocores/fbalibretro.sh
+++ b/scriptmodules/libretrocores/fbalibretro.sh
@@ -31,5 +31,5 @@ function install_fbalibretro() {
 function configure_fbalibretro() {
     mkdir -p $romdir/fba-libretro
 
-    setESSystem "Final Burn Alpha" "fba-libretro" "~/RetroPie/roms/fba-libretro" ".fba .FBA .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/fb_alpha_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/fba/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "arcade" "fba"
+    setESSystem "Final Burn Alpha" "fba-libretro" "~/RetroPie/roms/fba-libretro" ".fba .FBA .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/fb_alpha_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/fba/retroarch.cfg %ROM%\" \"$md_id\"" "arcade" "fba"
 }

--- a/scriptmodules/libretrocores/fbalibretro.sh
+++ b/scriptmodules/libretrocores/fbalibretro.sh
@@ -31,6 +31,5 @@ function install_fbalibretro() {
 function configure_fbalibretro() {
     mkdir -p $romdir/fba-libretro
 
-    rps_retronet_prepareConfig
-    setESSystem "Final Burn Alpha" "fba-libretro" "~/RetroPie/roms/fba-libretro" ".fba .FBA .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/fb_alpha_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/fba/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "arcade" "fba"
+    setESSystem "Final Burn Alpha" "fba-libretro" "~/RetroPie/roms/fba-libretro" ".fba .FBA .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/fb_alpha_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/fba/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "arcade" "fba"
 }

--- a/scriptmodules/libretrocores/fmsx-libretro.sh
+++ b/scriptmodules/libretrocores/fmsx-libretro.sh
@@ -25,5 +25,5 @@ function configure_fmsx-libretro() {
     mkRomDir "msx"
     ensureSystemretroconfig "msx"
 
-    setESSystem "MSX" "msx" "~/RetroPie/roms/msx" ".rom .ROM .mx1 .MX1 .mx2 .MX2 .col .COL .dsk .DSK .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fmsx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/msx/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "msx" "msx"
+    setESSystem "MSX" "msx" "~/RetroPie/roms/msx" ".rom .ROM .mx1 .MX1 .mx2 .MX2 .col .COL .dsk .DSK .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fmsx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/msx/retroarch.cfg %ROM%\" \"$md_id\"" "msx" "msx"
 }

--- a/scriptmodules/libretrocores/fmsx-libretro.sh
+++ b/scriptmodules/libretrocores/fmsx-libretro.sh
@@ -24,6 +24,6 @@ function install_fmsx-libretro() {
 function configure_fmsx-libretro() {
     mkRomDir "msx"
     ensureSystemretroconfig "msx"
-    rps_retronet_prepareConfig
-    setESSystem "MSX" "msx" "~/RetroPie/roms/msx" ".rom .ROM .mx1 .MX1 .mx2 .MX2 .col .COL .dsk .DSK .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fmsx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/msx/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "msx" "msx"
+
+    setESSystem "MSX" "msx" "~/RetroPie/roms/msx" ".rom .ROM .mx1 .MX1 .mx2 .MX2 .col .COL .dsk .DSK .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fmsx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/msx/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "msx" "msx"
 }

--- a/scriptmodules/libretrocores/libretro-handy.sh
+++ b/scriptmodules/libretrocores/libretro-handy.sh
@@ -23,5 +23,5 @@ function configure_libretro-handy() {
     mkRomDir "atarilynx"
     ensureSystemretroconfig "atarilynx"
 
-    setESSystem "Atari Lynx" "atarilynx" "~/RetroPie/roms/atarilynx" ".lnx .LNX .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/handy_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atarilynx/retroarch.cfg __retronet_params %ROM%\" \"$md_id\"" "atarilynx" "atarilynx"
+    setESSystem "Atari Lynx" "atarilynx" "~/RetroPie/roms/atarilynx" ".lnx .LNX .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/handy_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atarilynx/retroarch.cfg %ROM%\" \"$md_id\"" "atarilynx" "atarilynx"
 }

--- a/scriptmodules/libretrocores/libretro-handy.sh
+++ b/scriptmodules/libretrocores/libretro-handy.sh
@@ -22,6 +22,6 @@ function install_libretro-handy() {
 function configure_libretro-handy() {
     mkRomDir "atarilynx"
     ensureSystemretroconfig "atarilynx"
-    rps_retronet_prepareConfig
-    setESSystem "Atari Lynx" "atarilynx" "~/RetroPie/roms/atarilynx" ".lnx .LNX .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/handy_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atarilynx/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "atarilynx" "atarilynx"
+
+    setESSystem "Atari Lynx" "atarilynx" "~/RetroPie/roms/atarilynx" ".lnx .LNX .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/handy_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atarilynx/retroarch.cfg __retronet_params %ROM%\" \"$md_id\"" "atarilynx" "atarilynx"
 }

--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -139,5 +139,5 @@ target FPS=25
 _EOF_
     chown -R $user:$user "$home/RetroPie/BIOS"
 
-    setESSystem "Nintendo 64" "n64" "~/RetroPie/roms/n64" ".z64 .Z64 .n64 .N64 .v64 .V64 .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/mupen64plus_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/n64/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "n64" "n64"
+    setESSystem "Nintendo 64" "n64" "~/RetroPie/roms/n64" ".z64 .Z64 .n64 .N64 .v64 .V64 .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/mupen64plus_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/n64/retroarch.cfg %ROM%\" \"$md_id\"" "n64" "n64"
 }

--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -139,6 +139,5 @@ target FPS=25
 _EOF_
     chown -R $user:$user "$home/RetroPie/BIOS"
 
-    rps_retronet_prepareConfig
-    setESSystem "Nintendo 64" "n64" "~/RetroPie/roms/n64" ".z64 .Z64 .n64 .N64 .v64 .V64 .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/mupen64plus_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/n64/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile $__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "n64" "n64"
+    setESSystem "Nintendo 64" "n64" "~/RetroPie/roms/n64" ".z64 .Z64 .n64 .N64 .v64 .V64 .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/mupen64plus_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/n64/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "n64" "n64"
 }

--- a/scriptmodules/libretrocores/neslibretro.sh
+++ b/scriptmodules/libretrocores/neslibretro.sh
@@ -27,6 +27,5 @@ function install_neslibretro() {
 function configure_neslibretro() {
     mkRomDir "nes"
 
-    rps_retronet_prepareConfig
-    setESSystem "Nintendo Entertainment System" "nes" "~/RetroPie/roms/nes" ".nes .NES .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fceumm_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/nes/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "nes" "nes"
+    setESSystem "Nintendo Entertainment System" "nes" "~/RetroPie/roms/nes" ".nes .NES .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fceumm_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/nes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "nes" "nes"
 }

--- a/scriptmodules/libretrocores/neslibretro.sh
+++ b/scriptmodules/libretrocores/neslibretro.sh
@@ -27,5 +27,5 @@ function install_neslibretro() {
 function configure_neslibretro() {
     mkRomDir "nes"
 
-    setESSystem "Nintendo Entertainment System" "nes" "~/RetroPie/roms/nes" ".nes .NES .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fceumm_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/nes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "nes" "nes"
+    setESSystem "Nintendo Entertainment System" "nes" "~/RetroPie/roms/nes" ".nes .NES .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/fceumm_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/nes/retroarch.cfg %ROM%\" \"$md_id\"" "nes" "nes"
 }

--- a/scriptmodules/libretrocores/picodrive.sh
+++ b/scriptmodules/libretrocores/picodrive.sh
@@ -30,11 +30,11 @@ function configure_picodrive() {
     mkRomDir "sega32x"
 
     rps_retronet_prepareConfig
-    setESSystem "Sega Master System / Mark III" "mastersystem" "~/RetroPie/roms/mastersystem" ".sms .SMS .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/mastersystem/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "mastersystem" "mastersystem"
+    setESSystem "Sega Master System / Mark III" "mastersystem" "~/RetroPie/roms/mastersystem" ".sms .SMS .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/mastersystem/retroarch.cfg %ROM%\" \"$md_id\"" "mastersystem" "mastersystem"
 
-    setESSystem "Sega Mega Drive / Genesis" "megadrive" "~/RetroPie/roms/megadrive" ".smd .SMD .bin .BIN .gen .GEN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/megadrive/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "genesis,megadrive" "megadrive"
+    setESSystem "Sega Mega Drive / Genesis" "megadrive" "~/RetroPie/roms/megadrive" ".smd .SMD .bin .BIN .gen .GEN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/megadrive/retroarch.cfg %ROM%\" \"$md_id\"" "genesis,megadrive" "megadrive"
 
-    setESSystem "Sega CD" "segacd" "~/RetroPie/roms/segacd" ".smd .SMD .bin .BIN .md .MD .zip .ZIP .iso .ISO .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/segacd/retroarch.cfg  %ROM%\" \"$md_id\"" "segacd" "segacd"
+    setESSystem "Sega CD" "segacd" "~/RetroPie/roms/segacd" ".smd .SMD .bin .BIN .md .MD .zip .ZIP .iso .ISO .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/segacd/retroarch.cfg %ROM%\" \"$md_id\"" "segacd" "segacd"
 
-    setESSystem "Sega 32X" "sega32x" "~/RetroPie/roms/sega32x" ".32x .32X .smd .SMD .bin .BIN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/sega32x/retroarch.cfg  %ROM%\" \"$md_id\"" "sega32x" "sega32x"
+    setESSystem "Sega 32X" "sega32x" "~/RetroPie/roms/sega32x" ".32x .32X .smd .SMD .bin .BIN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/sega32x/retroarch.cfg %ROM%\" \"$md_id\"" "sega32x" "sega32x"
 }

--- a/scriptmodules/libretrocores/picodrive.sh
+++ b/scriptmodules/libretrocores/picodrive.sh
@@ -30,9 +30,9 @@ function configure_picodrive() {
     mkRomDir "sega32x"
 
     rps_retronet_prepareConfig
-    setESSystem "Sega Master System / Mark III" "mastersystem" "~/RetroPie/roms/mastersystem" ".sms .SMS .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/mastersystem/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "mastersystem" "mastersystem"
+    setESSystem "Sega Master System / Mark III" "mastersystem" "~/RetroPie/roms/mastersystem" ".sms .SMS .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/mastersystem/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "mastersystem" "mastersystem"
 
-    setESSystem "Sega Mega Drive / Genesis" "megadrive" "~/RetroPie/roms/megadrive" ".smd .SMD .bin .BIN .gen .GEN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/megadrive/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "genesis,megadrive" "megadrive"
+    setESSystem "Sega Mega Drive / Genesis" "megadrive" "~/RetroPie/roms/megadrive" ".smd .SMD .bin .BIN .gen .GEN .md .MD .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/megadrive/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "genesis,megadrive" "megadrive"
 
     setESSystem "Sega CD" "segacd" "~/RetroPie/roms/segacd" ".smd .SMD .bin .BIN .md .MD .zip .ZIP .iso .ISO .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/picodrive_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/segacd/retroarch.cfg  %ROM%\" \"$md_id\"" "segacd" "segacd"
 

--- a/scriptmodules/libretrocores/pocketsnes.sh
+++ b/scriptmodules/libretrocores/pocketsnes.sh
@@ -23,6 +23,5 @@ function install_pocketsnes() {
 function configure_pocketsnes() {
     mkRomDir "snes"
 
-    rps_retronet_prepareConfig
-    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile $__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "snes" "snes"
+    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "snes" "snes"
 }

--- a/scriptmodules/libretrocores/pocketsnes.sh
+++ b/scriptmodules/libretrocores/pocketsnes.sh
@@ -23,5 +23,5 @@ function install_pocketsnes() {
 function configure_pocketsnes() {
     mkRomDir "snes"
 
-    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "snes" "snes"
+    setESSystem "Super Nintendo" "snes" "~/RetroPie/roms/snes" ".smc .sfc .fig .swc .SMC .SFC .FIG .SWC .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/snes/retroarch.cfg %ROM%\" \"$md_id\"" "snes" "snes"
 }

--- a/scriptmodules/libretrocores/psxlibretro.sh
+++ b/scriptmodules/libretrocores/psxlibretro.sh
@@ -32,6 +32,5 @@ function install_psxlibretro() {
 function configure_psxlibretro() {
     mkRomDir "psx"
 
-    rps_retronet_prepareConfig
     setESSystem "Sony Playstation 1" "psx" "~/RetroPie/roms/psx" ".bin .BIN .cue .CUE .cbn .CBN .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .z .Z .znx .ZNX" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/psx/retroarch.cfg %ROM%\" \"$md_id\"" "psx" "psx"
 }

--- a/scriptmodules/libretrocores/stellalibretro.sh
+++ b/scriptmodules/libretrocores/stellalibretro.sh
@@ -22,6 +22,5 @@ function install_stellalibretro() {
 function configure_stellalibretro() {
     mkRomDir "atari2600-libretro"
 
-    rps_retronet_prepareConfig
-    setESSystem "Atari 2600" "atari2600-libretro" "~/RetroPie/roms/atari2600-libretro" ".a26 .A26 .bin .BIN .rom .ROM .zip .ZIP .gz .GZ" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/stella_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atari2600/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile$__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "atari2600" "atari2600"
+    setESSystem "Atari 2600" "atari2600-libretro" "~/RetroPie/roms/atari2600-libretro" ".a26 .A26 .bin .BIN .rom .ROM .zip .ZIP .gz .GZ" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/stella_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atari2600/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "atari2600" "atari2600"
 }

--- a/scriptmodules/libretrocores/stellalibretro.sh
+++ b/scriptmodules/libretrocores/stellalibretro.sh
@@ -22,5 +22,5 @@ function install_stellalibretro() {
 function configure_stellalibretro() {
     mkRomDir "atari2600-libretro"
 
-    setESSystem "Atari 2600" "atari2600-libretro" "~/RetroPie/roms/atari2600-libretro" ".a26 .A26 .bin .BIN .rom .ROM .zip .ZIP .gz .GZ" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/stella_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atari2600/retroarch.cfg $__retronet_params %ROM%\" \"$md_id\"" "atari2600" "atari2600"
+    setESSystem "Atari 2600" "atari2600-libretro" "~/RetroPie/roms/atari2600-libretro" ".a26 .A26 .bin .BIN .rom .ROM .zip .ZIP .gz .GZ" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/stella_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/atari2600/retroarch.cfg %ROM%\" \"$md_id\"" "atari2600" "atari2600"
 }

--- a/scriptmodules/libretrocores/turbografx16.sh
+++ b/scriptmodules/libretrocores/turbografx16.sh
@@ -22,6 +22,5 @@ function install_turbografx16() {
 function configure_turbografx16() {
     mkRomDir "pcengine-libretro"
 
-    rps_retronet_prepareConfig
     setESSystem "TurboGrafx 16 (PC Engine)" "pcengine-libretro" "~/RetroPie/roms/pcengine-libretro" ".pce .PCE .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/pcengine/retroarch.cfg %ROM%\" \"$md_id\"" "pcengine" "pcengine"
 }

--- a/scriptmodules/libretrocores/tyrquake.sh
+++ b/scriptmodules/libretrocores/tyrquake.sh
@@ -46,7 +46,7 @@ function configure_tyrquake() {
     # Create startup script
     cat > "$romdir/ports/Quake.sh" << _EOF_
 #!/bin/bash
-$rootdir/supplementary/runcommand/runcommand.sh 4 "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/quake/retroarch.cfg $__retronet_params $romdir/ports/quake/id1/pak0.pak" "$md_id"
+$rootdir/supplementary/runcommand/runcommand.sh 4 "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/quake/retroarch.cfg $romdir/ports/quake/id1/pak0.pak" "$md_id"
 _EOF_
 
     chmod +x "$romdir/ports/Quake.sh"

--- a/scriptmodules/libretrocores/tyrquake.sh
+++ b/scriptmodules/libretrocores/tyrquake.sh
@@ -46,13 +46,10 @@ function configure_tyrquake() {
     # Create startup script
     cat > "$romdir/ports/Quake.sh" << _EOF_
 #!/bin/bash
-$rootdir/supplementary/runcommand/runcommand.sh 4 "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/quake/retroarch.cfg  $romdir/ports/quake/id1/pak0.pak" "$md_id"
+$rootdir/supplementary/runcommand/runcommand.sh 4 "$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/quake/retroarch.cfg $__retronet_params $romdir/ports/quake/id1/pak0.pak" "$md_id"
 _EOF_
 
     chmod +x "$romdir/ports/Quake.sh"
 
     setESSystem 'Ports' 'ports' '~/RetroPie/roms/ports' '.sh .SH' '%ROM%' 'pc' 'ports'
-    
-    # Quake Shareware: Please copy pak0.pak to rom folder
-    # setESSystem "Quake" "quake" "~/RetroPie/roms/quake" ".PAK .pak" "$rootdir/supplementary/runcommand/runcommand.sh 4 \"$emudir/retroarch/bin/retroarch -L $md_inst/tyrquake_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/quake/retroarch.cfg $__tmpnetplaymode$__tmpnetplayhostip_cfile $__tmpnetplayport$__tmpnetplayframes %ROM%\" \"$md_id\"" "quake" "quake"
 }

--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -59,18 +59,6 @@ _EOF_
     iniSet "gpu_mem_512" 256
     iniSet "overscan_scale" 1
 
-    if [[ $__netplayenable == "E" ]]; then
-         local __tmpnetplaymode="-$__netplaymode "
-         local __tmpnetplayhostip_cfile=$__netplayhostip_cfile
-         local __tmpnetplayport="--port $__netplayport "
-         local __tmpnetplayframes="--frames $__netplayframes"
-     else
-         local __tmpnetplaymode=""
-         local __tmpnetplayhostip_cfile=""
-         local __tmpnetplayport=""
-         local __tmpnetplayframes=""
-     fi
-
     mkdir -p "/etc/emulationstation"
 
     setESSystem "Input Configuration" "esconfig" "~/RetroPie/roms/esconfig" ".py .PY" "%ROM%" "ignore" "esconfig"

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -21,25 +21,9 @@ function rps_retronet_loadconfig() {
         __netplayenable="D"
         __netplaymode="H"
         __netplayport="55435"
-        __netplayhostip=""
+        __netplayhostip="192.168.0.1"
         __netplayhostip_cfile=""
         __netplayframes="15"
-    fi
-}
-
-function rps_retronet_enable() {
-    cmd=(dialog --backtitle "$__backtitle" --menu "Enable or disable RetroArch's Netplay mode." 22 76 16)
-    options=(1 "ENABLE netplay"
-             2 "DISABLE netplay" )
-    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choice" ]]; then
-        case "$choice" in
-             1) __netplayenable="E"
-                ;;
-             2) __netplayenable="D"
-                ;;
-        esac
-        rps_retronet_saveconfig
     fi
 }
 
@@ -98,7 +82,6 @@ function configure_retronetplay() {
 
     local ip_int=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
     local ip_ext=$(wget -O- -q http://ipecho.net/plain)
-    [[ -z "$__netplayhostip" ]] && __netplayhostip="$ip_int"
 
     while true; do
         cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -5,7 +5,6 @@ rp_module_flags="nobin"
 
 function rps_retronet_saveconfig() {
     cat > "$rootdir/configs/all/retronetplay.cfg" <<_EOF_
-__netplayenable="$__netplayenable"
 __netplaymode="$__netplaymode"
 __netplayport="$__netplayport"
 __netplayhostip="$__netplayhostip"
@@ -103,19 +102,17 @@ function configure_retronetplay() {
 
     while true; do
         cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ip_int External IP: $ip_ext" 22 76 16)
-        options=(1 "(E)nable/(D)isable RetroArch Netplay. Currently: $__netplayenable"
-                 2 "Set mode, (H)ost or (C)lient. Currently: $__netplaymode"
-                 3 "Set port. Currently: $__netplayport"
-                 4 "Set host IP address (for client mode). Currently: $__netplayhostip"
-                 5 "Set delay frames. Currently: $__netplayframes")
+        options=(1 "Set mode, (H)ost or (C)lient. Currently: $__netplaymode"
+                 2 "Set port. Currently: $__netplayport"
+                 3 "Set host IP address (for client mode). Currently: $__netplayhostip"
+                 4 "Set delay frames. Currently: $__netplayframes")
         choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
         if [[ -n "$choice" ]]; then
             case $choice in
-                 1) rps_retronet_enable ;;
-                 2) rps_retronet_mode ;;
-                 3) rps_retronet_port ;;
-                 4) rps_retronet_hostip ;;
-                 5) rps_retronet_frames ;;
+                 1) rps_retronet_mode ;;
+                 2) rps_retronet_port ;;
+                 3) rps_retronet_hostip ;;
+                 4) rps_retronet_frames ;;
             esac
         else
             break

--- a/scriptmodules/supplementary/retronetplay.sh
+++ b/scriptmodules/supplementary/retronetplay.sh
@@ -3,13 +3,26 @@ rp_module_desc="RetroNetplay"
 rp_module_menus="4+"
 rp_module_flags="nobin"
 
+function rps_retronet_saveconfig() {
+    cat > "$rootdir/configs/all/retronetplay.cfg" <<_EOF_
+__netplayenable="$__netplayenable"
+__netplaymode="$__netplaymode"
+__netplayport="$__netplayport"
+__netplayhostip="$__netplayhostip"
+__netplayhostip_cfile="$__netplayhostip_cfile"
+__netplayframes="$__netplayframes"
+_EOF_
+    chown $user:$user "$rootdir/configs/all/retronetplay.cfg"
+    retronetParams
+}
+
 function rps_retronet_enable() {
     cmd=(dialog --backtitle "$__backtitle" --menu "Enable or disable RetroArch's Netplay mode." 22 76 16)
     options=(1 "ENABLE netplay"
              2 "DISABLE netplay" )
-    choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choices" ]]; then
-        case $choices in
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        case "$choice" in
              1) __netplayenable="E"
                 ;;
              2) __netplayenable="D"
@@ -23,9 +36,9 @@ function rps_retronet_mode() {
     cmd=(dialog --backtitle "$__backtitle" --menu "Please set the netplay mode." 22 76 16)
     options=(1 "Set as HOST"
              2 "Set as CLIENT" )
-    choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choices" ]]; then
-        case $choices in
+    choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        case "$choice" in
              1) __netplaymode="H"
                 __netplayhostip_cfile=""
                 ;;
@@ -39,18 +52,18 @@ function rps_retronet_mode() {
 
 function rps_retronet_port() {
     cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the port to be used for netplay (default: 55435)." 22 76 $__netplayport)
-    choices=$("${cmd[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choices" ]]; then
-        __netplayport=$choices
+    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        __netplayport="$choice"
         rps_retronet_saveconfig
     fi
 }
 
 function rps_retronet_hostip() {
     cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the IP address of the host." 22 76 $__netplayhostip)
-    choices=$("${cmd[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choices" ]]; then
-        __netplayhostip=$choices
+    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        __netplayhostip="$choice"
         if [[ $__netplaymode == "H" ]]; then
             __netplayhostip_cfile=""
         else
@@ -62,55 +75,34 @@ function rps_retronet_hostip() {
 
 function rps_retronet_frames() {
     cmd=(dialog --backtitle "$__backtitle" --inputbox "Please enter the number of delay frames for netplay (default: 15)." 22 76 $__netplayframes)
-    choices=$("${cmd[@]}" 2>&1 >/dev/tty)
-    if [[ -n "$choices" ]]; then
-        __netplayframes=$choices
+    choice=$("${cmd[@]}" 2>&1 >/dev/tty)
+    if [[ -n "$choice" ]]; then
+        __netplayframes="$choice"
         rps_retronet_saveconfig
     fi
 }
 
-function rps_retronet_saveconfig() {
-    echo -e "__netplayenable=\"$__netplayenable\"\n__netplaymode=\"$__netplaymode\"\n__netplayport=\"$__netplayport\"\n__netplayhostip=\"$__netplayhostip\"\n__netplayhostip_cfile=\"$__netplayhostip_cfile\"\n__netplayframes=\"$__netplayframes\"" > $scriptdir/configs/retronetplay.cfg
-}
-
-function rps_retronet_prepareConfig() {
-    if [[ $__netplayenable == "E" ]]; then
-         __tmpnetplaymode="-$__netplaymode "
-         __tmpnetplayhostip_cfile=$__netplayhostip_cfile
-         __tmpnetplayport="--port $__netplayport "
-         __tmpnetplayframes="--frames $__netplayframes"
-     else
-         __tmpnetplaymode=""
-         __tmpnetplayhostip_cfile=""
-         __tmpnetplayport=""
-         __tmpnetplayframes=""
-     fi    
-}
-
 function rps_retronet_updateESConfiguration() {
-        # configure all libretro components
+        # configure all libretro components (except experimental)
         for idx in "${__mod_idx[@]}"; do
-            [[ $idx -ge 200 ]] && [[ $idx -lt 300 ]] && rp_callModule "$idx" "configure"
+            [[ $idx -ge 200 ]] && [[ $idx -lt 300 ]] && [[ ! "${__mod_menus[$idx]}" =~ 4 ]] && rp_callModule "$idx" "configure"
         done    
 }
 
 function configure_retronetplay() {
-    # load RetronetPlay configuration
-    source "$scriptdir/configs/retronetplay.cfg"
-
     ipaddress_int=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
-    ipaddress_ext=$(curl http://ipecho.net/plain; echo)
+    ipaddress_ext=$(curl http://ipecho.net/plain)
     while true; do
-        cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ipaddress_int\nExternal IP: $ipaddress_ext" 22 76 16)
+        cmd=(dialog --backtitle "$__backtitle" --menu "Configure RetroArch Netplay.\nInternal IP: $ipaddress_int External IP: $ipaddress_ext" 22 76 16)
         options=(1 "(E)nable/(D)isable RetroArch Netplay. Currently: $__netplayenable"
                  2 "Set mode, (H)ost or (C)lient. Currently: $__netplaymode"
                  3 "Set port. Currently: $__netplayport"
                  4 "Set host IP address (for client mode). Currently: $__netplayhostip"
                  5 "Set delay frames. Currently: $__netplayframes" 
                  6 "Update EmulationStation configuration")
-        choices=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
-        if [[ -n "$choices" ]]; then
-            case $choices in
+        choice=$("${cmd[@]}" "${options[@]}" 2>&1 >/dev/tty)
+        if [[ -n "$choice" ]]; then
+            case $choice in
                  1) rps_retronet_enable ;;
                  2) rps_retronet_mode ;;
                  3) rps_retronet_port ;;

--- a/supplementary/runcommand.sh
+++ b/supplementary/runcommand.sh
@@ -100,7 +100,6 @@ function main_menu() {
             3)
                 sed -i "/$romsave/d" "$video_conf"
                 get_mode "$emusave"
-                return
                 ;;
             Z)
                 netplay=1

--- a/supplementary/runcommand.sh
+++ b/supplementary/runcommand.sh
@@ -80,10 +80,10 @@ function main_menu() {
             1 "Select default video mode for emulator/port"
             2 "Select default video mode for game/rom"
             3 "Remove default video mode for game/rom"
-            X "Launch game/rom")
+            X "Launch")
 
         if [[ "$command" =~ retroarch ]]; then
-            options+=(Z "Launch game with netplay enabled")
+            options+=(Z "Launch with netplay enabled")
         fi
 
         cmd=(dialog --menu "Launch configuration configuration for emulator/port $emulator"  22 76 16 )

--- a/supplementary/runcommand.sh
+++ b/supplementary/runcommand.sh
@@ -194,7 +194,7 @@ function retroarch_append_config() {
         source "$retronetplay_conf"
         retronetplay=" -$__netplaymode $__netplayhostip_cfile --port $__netplayport --frames $__netplayframes"
     else
-        _retronetplay=""
+        retronetplay=""
     fi
     command=$(echo "$command" | sed "s|\(--appendconfig *[^ $]*\)|\1,/tmp/retroarch-rate.cfg$retronetplay|")
 }


### PR DESCRIPTION
cleanup of retronetplay …

 * moved config to $rootdir/configs/all/retronetplay.cfg
 * reduce complexity of parameters passed to setESSystem
 * code duplication / cleanup etc
 * use runcommand.sh to handle netplay parameters - which is better than having to regenerate emulationstation configs all the time and simplifies things
 * instead of having to go into retronetplay configuration to enable/disable it (and then back to emulationstation etc), add the option to launch with netplay enabled into the runcommand.sh menu