### PR TITLE
ps3controller: Fix sixpair path

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -37,7 +37,7 @@ function configure_ps3controller() {
     fi
 
     dialog --backtitle "$__backtitle" --msgbox "Please connect your PS3 controller via USB-CABLE and press ENTER." 22 76
-    if ./sixpair | grep -q "Setting master"; then
+    if $md_inst/sixpair | grep -q "Setting master"; then
         dialog --backtitle "$__backtitle" --msgbox "Cannot find the PS3 controller via USB-connection. Please try to (re-)connect it and try again." 22 76
         break
     fi


### PR DESCRIPTION
The PS3 installation always fails at line 40. Should be fixed with the right sixpair path. See:
http://blog.petrockblock.com/forums/topic/possible-script-error-in-retropie/