### PR TITLE
Move MUPEN64Plus to source based installations.

### DIFF
--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -1,15 +1,15 @@
-rp_module_id="mupen64rpi"
-rp_module_desc="N64 emulator MUPEN64Plus-RPi"
-rp_module_menus="4+"
+rp_module_id="mupen64plus"
+rp_module_desc="N64 emulator MUPEN64Plus"
+rp_module_menus="2+"
 rp_module_flags="!odroid"
 
-function depends_mupen64rpi() {
+function depends_mupen64plus() {
     if ! hasPackage libsdl2-dev && isPlatform "rpi"; then
         rp_callModule sdl2 install_bin
     fi
 }
 
-function sources_mupen64rpi() {
+function sources_mupen64plus() {
     local repos=(
         'ricrpi core ric_dev'
         'mupen64plus ui-console'
@@ -27,7 +27,7 @@ function sources_mupen64rpi() {
     done
 }
 
-function build_mupen64rpi() {
+function build_mupen64plus() {
     rpSwap on 750
 
     local dir
@@ -45,7 +45,7 @@ function build_mupen64rpi() {
     rpSwap off
 }
 
-function install_mupen64rpi() {
+function install_mupen64plus() {
     for source in *; do
         if [[ -f "$source/projects/unix/Makefile" ]]; then
             # optflags is needed due to the fact the core seems to rebuild 2 files and relink during install stage most likely due to a buggy makefile
@@ -54,7 +54,7 @@ function install_mupen64rpi() {
     done
 }
 
-function configure_mupen64rpi() {
+function configure_mupen64plus() {
     # to solve startup problems delete old config file
     rm -f "$home/.config/mupen64plus/mupen64plus.cfg"
 

--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -1,12 +1,12 @@
-rp_module_id="mupen64plus"
-rp_module_desc="N64 LibretroCore Mupen64Plus"
+rp_module_id="mupen64plus-libretro"
+rp_module_desc="N64 LibretroCore MUPEN64Plus"
 rp_module_menus="2+"
 
-function sources_mupen64plus() {
+function sources_mupen64plus-libretro() {
     gitPullOrClone "$md_build" git://github.com/libretro/mupen64plus-libretro.git
 }
 
-function build_mupen64plus() {
+function build_mupen64plus-libretro() {
     rpSwap on 750
     make clean
     make platform=rpi
@@ -14,7 +14,7 @@ function build_mupen64plus() {
     md_ret_require="$md_build/mupen64plus_libretro.so"
 }
 
-function install_mupen64plus() {
+function install_mupen64plus-libretro() {
     md_ret_files=(
         'mupen64plus-core/data'
         'mupen64plus_libretro.so'
@@ -22,7 +22,7 @@ function install_mupen64plus() {
     )
 }
 
-function configure_mupen64plus() {
+function configure_mupen64plus-libretro() {
     mkRomDir "n64"
     ensureSystemretroconfig "n64"
 


### PR DESCRIPTION
The module should be ready now (again). I renamed mupen64plus because we don't use the deprecated mupen64plus-rpi repo. 
