### PR TITLE
retroarch: Add SDL2 dependency

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -4,6 +4,11 @@ rp_module_menus="2+"
 
 function depends_retroarch() {
     getDepends libudev-dev libxkbcommon-dev
+    
+    if ! hasPackage libsdl2-dev && isPlatform "rpi"; then
+        rp_callModule sdl2 install_bin
+    fi
+    
     cat > "/etc/udev/rules.d/99-evdev.rules" << _EOF_
 KERNEL=="event*", NAME="input/%k", MODE="666"
 _EOF_


### PR DESCRIPTION
To fix this issue: https://github.com/petrockblog/RetroPie-Setup/issues/623