### PR TITLE
mupen64plus-testing: Fix typo

### DIFF
--- a/scriptmodules/emulators/mupen64plus-testing.sh
+++ b/scriptmodules/emulators/mupen64plus-testing.sh
@@ -245,7 +245,7 @@ _EOF_
     cp -v "$md_inst/share/mupen64plus/"{*.ini,font.ttf} "$rootdir/configs/n64/"
     chown -R $user:$user "$rootdir/configs/n64"
     su "$user" -c "$md_inst/bin/mupen64plus --configdir $rootdir/configs/n64 --datadir $rootdir/configs/n64"
-    # iniConfig " = " "" "$rootdir/configs/n64/mupen64plus.cfg"
+    iniConfig " = " "" "$rootdir/configs/n64/mupen64plus.cfg"
     # iniSet "VideoPlugin" "mupen64plus-video-n64"
     iniSet "AudioPlugin" "mupen64plus-audio-omx"
     # Enable bilinear filtering for rice


### PR DESCRIPTION
@joolswills @petrockblog 
Please add this fix. The module is not working if iniConfig is not set.