### PR TITLE
mupen64plus-libretro: Don't use rpi2 target for now.

### DIFF
--- a/scriptmodules/libretrocores/mupen64libretro.sh
+++ b/scriptmodules/libretrocores/mupen64libretro.sh
@@ -13,11 +13,11 @@ function sources_mupen64plus-libretro() {
 function build_mupen64plus-libretro() {
     rpSwap on 750
     make clean
-    if isPlatform "rpi2"; then
-        make platform=rpi2
-    else
+    #if isPlatform "rpi2"; then
+    #    make platform=rpi2
+    #else
         make platform=rpi
-    fi
+    #fi
     rpSwap off
     md_ret_require="$md_build/mupen64plus_libretro.so"
 }


### PR DESCRIPTION
It always crashes with a segfault. If -mfpu=neon-vfp4 is set the libretrocore will crash.