### PR TITLE
remove binaries update - this option is no longer useful and users are c...

### DIFF
--- a/scriptmodules/retropiesetup.sh
+++ b/scriptmodules/retropiesetup.sh
@@ -105,6 +105,7 @@ rps_main_menu() {
         if [[ $__has_binaries -eq 1 ]]; then
             options+=(
                 5 "INSTALL individual emulators from binary or source"
+                6 "UPDATE RetroPie Binaries"
             )
         else
             options+=(5 "INSTALL individual emulators from source")
@@ -121,6 +122,7 @@ rps_main_menu() {
                 3) rps_main_setup ;;
                 4) rps_main_experimental ;;
                 5) rps_install_individual ;;
+                6) rps_downloadBinaries ;;
                 U) rps_main_updatescript ;;
                 R) rps_main_reboot ;;
             esac
@@ -207,7 +209,12 @@ function rps_main_updatescript()
         popd
         return
     fi
-    git pull
+    local error
+    if ! error=$(git pull 2>&1 >/dev/null); then
+        dialog --backtitle "$__backtitle" --msgbox "Update failed:\n\n$error" 20 60
+        popd
+        return
+    fi
     popd
     printMsg "Updating ESConfigEdit script."
     updateESConfigEdit

--- a/scriptmodules/retropiesetup.sh
+++ b/scriptmodules/retropiesetup.sh
@@ -105,7 +105,6 @@ rps_main_menu() {
         if [[ $__has_binaries -eq 1 ]]; then
             options+=(
                 5 "INSTALL individual emulators from binary or source"
-                6 "UPDATE RetroPie Binaries"
             )
         else
             options+=(5 "INSTALL individual emulators from source")
@@ -122,7 +121,6 @@ rps_main_menu() {
                 3) rps_main_setup ;;
                 4) rps_main_experimental ;;
                 5) rps_install_individual ;;
-                6) rps_downloadBinaries ;;
                 U) rps_main_updatescript ;;
                 R) rps_main_reboot ;;
             esac


### PR DESCRIPTION
...onstantly using it and then reporting stuff as not working due to missing dependencies etc from updated binaries.

one way forward would be to make it check dates of archives and work on that, but option 1 is the best way to update everything, and it doesn't take very long. Also users
can update individual components from menu 5 which will run depends/configure etc.