### PR TITLE
genesis: Add genesis mastersystem emulator to emulationstation

### DIFF
--- a/scriptmodules/libretrocores/genesislibretro.sh
+++ b/scriptmodules/libretrocores/genesislibretro.sh
@@ -23,7 +23,12 @@ function install_genesislibretro() {
 
 function configure_genesislibretro() {
     mkRomDir "gamegear"
+    mkRomDir "mastersystem-genesis"
+    
     ensureSystemretroconfig "gamegear"
+    ensureSystemretroconfig "mastersystem-genesis"
+
+    setESSystem "Sega Master System / Mark III" "mastersystem-genesis" "~/RetroPie/roms/mastersystem-genesis" ".sms .SMS .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/genesis_plus_gx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/mastersystem/retroarch.cfg %ROM%\" \"$md_id\"" "mastersystem" "mastersystem"
 
     setESSystem "Sega Game Gear" "gamegear" "~/RetroPie/roms/gamegear" ".gg .GG .zip .ZIP" "$rootdir/supplementary/runcommand/runcommand.sh 1 \"$emudir/retroarch/bin/retroarch -L $md_inst/genesis_plus_gx_libretro.so --config $configdir/all/retroarch.cfg --appendconfig $configdir/gamegear/retroarch.cfg  %ROM%\" \"$md_id\"" "gamegear" "gamegear"
 }


### PR DESCRIPTION
Some users mentioned genesis core runs better as picodrive.
http://blog.petrockblock.com/forums/topic/has-anyone-gotten-phantasy-star-1-to-work/#post-86668