### PR TITLE
RetroArch: Disable search box until there is a fix

### DIFF
--- a/scriptmodules/emulators/retroarch.sh
+++ b/scriptmodules/emulators/retroarch.sh
@@ -15,6 +15,7 @@ function sources_retroarch() {
     gitPullOrClone "$md_build" git://github.com/libretro/RetroArch.git
     gitPullOrClone "$md_build/overlays" git://github.com/libretro/common-overlays.git
     gitPullOrClone "$md_build/assets" git://github.com/libretro/retroarch-assets.git
+    sed -i 's| menu_input_search_start|//menu_input_search_start|g' $md_build/menu/menu_entries_cbs_iterate.c
 }
 
 function build_retroarch() {


### PR DESCRIPTION
Get rid of this annoying search box joypad mapping until there is a real fix:
http://blog.petrockblock.com/forums/topic/controlle-issuesfreezing-when-accidentally-pushing-search-button/#post-90387
I have already done a PR but it was rejected. I have no interest hard boot my rpi every time i accidentally press x in RGUI so my SD card gets corrupted or something else. 