### PR TITLE
Cleanup

### DIFF
--- a/scriptmodules/emulators/mupen64plus-testing.sh
+++ b/scriptmodules/emulators/mupen64plus-testing.sh
@@ -49,11 +49,9 @@ function build_mupen64plus-testing() {
             if isPlatform "rpi2"; then
                 [[ "$dir" == "mupen64plus-core" ]] && params+=("VC=1" "NEON=1")
                 [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1" "NEON=1")
-                [[ "$dir" == "mupen64plus-video-gles2n64-1" ]] && params+=("VC=1" "NEON=1")
             else
                 [[ "$dir" == "mupen64plus-core" ]] && params+=("VC=1" "VFP_HARD=1")
-                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1")
-                [[ "$dir" == "mupen64plus-video-gles2n64-1" ]] && params+=("VC=1")
+                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1" "VFP=1")
             fi
             make -C "$dir/projects/unix" all "${params[@]}" OPTFLAGS="$CFLAGS"
         fi

--- a/scriptmodules/emulators/mupen64plus.sh
+++ b/scriptmodules/emulators/mupen64plus.sh
@@ -4,18 +4,21 @@ rp_module_menus="2+"
 rp_module_flags="!odroid"
 
 function depends_mupen64plus() {
-    getDepends libsdl2-dev
+    getDepends libsamplerate0-dev libspeexdsp-dev libsdl2-dev
 }
 
 function sources_mupen64plus() {
     local repos=(
-        'ricrpi core ric_dev'
+        #'ricrpi core ric_dev'
+        'mupen64plus core'
         'mupen64plus ui-console'
         'ricrpi audio-omx'
         'mupen64plus audio-sdl'
         'mupen64plus input-sdl'
-        'ricrpi rsp-hle'
-        'ricrpi video-gles2rice'
+        #'ricrpi rsp-hle'
+        'mupen64plus rsp-hle'
+        #'ricrpi video-gles2rice'
+        'mupen64plus video-rice'
         'ricrpi video-gles2n64'
     )
     local repo
@@ -42,13 +45,14 @@ function build_mupen64plus() {
             params=()
             [[ "$dir" == "mupen64plus-ui-console" ]] && params+=("COREDIR=$md_inst/lib/" "PLUGINDIR=$md_inst/lib/mupen64plus/")
             [[ "$dir" == "mupen64plus-video-gles2rice" ]] && params+=("VC=1")
+            [[ "$dir" == "mupen64plus-video-rice" ]] && params+=("VC=1")
             [[ "$dir" == "mupen64plus-audio-omx" ]] && params+=("VC=1")
             if isPlatform "rpi2"; then
-                [[ "$dir" == "mupen64plus-core" ]] && params+=("USE_GLES=1" "NEON=1" "VC=1")
-                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("NEON=1" "VC=1")
+                [[ "$dir" == "mupen64plus-core" ]] && params+=("VC=1" "NEON=1")
+                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1" "NEON=1")
             else
-                [[ "$dir" == "mupen64plus-core" ]] && params+=("USE_GLES=1" "VFP=1" "VFP_HARD=1" "VC=1")
-                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1")
+                [[ "$dir" == "mupen64plus-core" ]] && params+=("VC=1" "VFP_HARD=1")
+                [[ "$dir" == "mupen64plus-video-gles2n64" ]] && params+=("VC=1" "VFP=1")
             fi
             make -C "$dir/projects/unix" all "${params[@]}" OPTFLAGS="$CFLAGS"
         fi
@@ -68,197 +72,37 @@ function install_mupen64plus() {
 
 function configure_mupen64plus() {
     # to solve startup problems delete old config file
-    rm -f "$home/.config/mupen64plus/mupen64plus.cfg"
-
+    rm -f "$configdir/n64/mupen64plus.cfg"
     mkdir -p "$configdir/n64/"
-    cat > "$configdir/n64/gles2n64.conf" << _EOF_
-#gles2n64 Graphics Plugin for N64
-#by Orkin / glN64 developers and Adventus.
-config version=2
-#These values are the physical pixel dimensions of
-#your screen. They are only used for centering the
-#window.
-screen width=640
-screen height=480
-#The Window position and dimensions specify how and
-#where the games will appear on the screen. Enabling
-#Centre will ensure that the window is centered
-#within the screen (overriding xpos/ypos).
-window enable x11=0
-window fullscreen=1
-window centre=1
-window xpos=0
-window ypos=0
-window width=640
-window height=480
-#Enabling offscreen frambuffering allows the resulting
-#image to be upscaled to the window dimensions. The
-#framebuffer dimensions specify the resolution which
-#gles2n64 will render to.
-framebuffer enable=1
-framebuffer bilinear=0
-framebuffer width=640
-framebuffer height=480
-#VI Settings, useful for forcing certain internal resolutions.
-video force=0
-video width=640
-video height=480
-#Frameskipping allows more CPU time be spent on other
-#tasks than GPU emulation, but at the cost of a lower
-#framerate.
-auto frameskip=1
-target FPS=20
-frame render rate=1
-#Vertical Sync Divider (0=No VSYNC, 1=60Hz, 2=30Hz, etc)
-vertical sync=0
-#These options enable different rendering paths, they
-#can relieve pressure on the GPU / CPU.
-enable fog=0
-enable primitive z=1
-enable lighting=1
-enable alpha test=1
-enable clipping=0
-enable face culling=1
-enable noise=0
-#Texture Bit Depth (0=force 16bit, 1=either 16/32bit, 2=force 32bit)
-texture depth=1
-texture 2xSAI=0
-texture force bilinear=0
-texture max anisotropy=0
-texture use IA=0
-texture fast CRC=1
-texture pow2=1
-#
-update mode=1
-ignore offscreen rendering=0
-force screen clear=1
-tribuffer opt=1
-flip vertical=0
-hack banjo tooie=0
-hack zelda=0
-hack alpha=0
-hack z=0
-#
-# Raspberry Pi options:
-# ----------------------------------------------------------------------
-# Use multisampling antialiasing (0=disabled, 2=2x multisampling)
-multisampling=0
-_EOF_
-
-    cat > "$configdir/n64/gles2n64rom.conf" << _EOF_
-#rom specific settings
-
-rom name=SUPER MARIO 64
-target FPS=25
-
-rom name=Kirby64
-target FPS=25
-
-rom name=Banjo-Kazooie
-framebuffer enable=1
-update mode=4
-target FPS=25
-
-rom name=BANJO TOOIE
-hack banjo tooie=1
-ignore offscreen rendering=1
-framebuffer enable=1
-update mode=4
-
-rom name=STARFOX64
-window width=864
-window height=520
-target FPS=27
-
-rom name=MARIOKART64
-target FPS=27
-
-rom name=THE LEGEND OF ZELDA
-texture use IA=0
-hack zelda=1
-target FPS=17
-
-rom name=ZELDA MAJORA'S MASK
-texture use IA=0
-hack zelda=1
-rom name=F-ZERO X
-window width=864
-window height=520
-target FPS=55
-rom name=WAVE RACE 64
-window width=864
-window height=520
-target FPS=27
-rom name=SMASH BROTHERS
-framebuffer enable=1
-window width=864
-window height=520
-target FPS=27
-rom name=1080 SNOWBOARDING
-update mode=2
-target FPS=27
-rom name=PAPER MARIO
-update mode=4
-rom name=STAR WARS EP1 RACER
-video force=1
-video width=320
-video height=480
-rom name=JET FORCE GEMINI
-framebuffer enable=1
-update mode=2
-ignore offscreen rendering=1
-target FPS=27
-rom name=RIDGE RACER 64
-window width=864
-window height=520
-enable lighting=0
-target FPS=27
-rom name=Diddy Kong Racing
-target FPS=27
-rom name=MarioParty
-update mode=4
-rom name=MarioParty3
-update mode=4
-rom name=Beetle Adventure Rac
-window width=864
-window height=520
-target FPS=27
-rom name=EARTHWORM JIM 3D
-rom name=LEGORacers
-rom name=GOEMONS GREAT ADV
-window width=864
-window height=520
-rom name=Buck Bumble
-window width=864
-window height=520
-rom name=BOMBERMAN64U2
-window width=864
-window height=520
-rom name=ROCKETROBOTONWHEELS
-window width=864
-window height=520
-rom name=GOLDENEYE
-force screen clear=1
-framebuffer enable=1
-window width=864
-window height=520
-target FPS=25
-rom name=Mega Man 64
-framebuffer enable=1
-target FPS=25
-_EOF_
-
     # Copy config files
-    cp -v "$md_inst/share/mupen64plus/"{*.ini,font.ttf} "$configdir/n64/"
-    chown -R $user:$user "$configdir/n64"
+    cp -v "$md_inst/share/mupen64plus/"{*.ini,font.ttf,*.conf} "$configdir/n64/"
+    cat > "$configdir/n64/mupen64plus.cfg" << _EOF_
+    [Video-Rice]
+# Control when the screen will be updated (0=ROM default, 1=VI origin update, 2=VI origin change, 3=CI change, 4=first CI change, 5=first primitive draw, 6=before screen clear, 7=after screen drawn)
+ScreenUpdateSetting = 6
+# Frequency to write back the frame buffer (0=every frame, 1=every other frame, etc)
+FrameBufferWriteBackControl = 1
+# If this option is enabled, the plugin will skip every other frame
+SkipFrame = False
+# If this option is enabled, the plugin will only draw every other screen update
+SkipScreenUpdate = False
+# Force to use texture filtering or not (0=auto: n64 choose, 1=force no filtering, 2=force filtering)
+ForceTextureFilter = 2
+# Primary texture enhancement filter (0=None, 1=2X, 2=2XSAI, 3=HQ2X, 4=LQ2X, 5=HQ4X, 6=Sharpen, 7=Sharpen More, 8=External, 9=Mirrored)
+TextureEnhancement = 6
+# Secondary texture enhancement filter (0 = none, 1-4 = filtered)
+TextureEnhancementControl = 0
 
+[Video-Glide64mk2]
+# Wrapper FBO
+wrpFBO = False
+_EOF_
+    chown -R $user:$user "$configdir/n64"
     su "$user" -c "$md_inst/bin/mupen64plus --configdir $configdir/n64 --datadir $configdir/n64"
     iniConfig " = " "" "$configdir/n64/mupen64plus.cfg"
     iniSet "VideoPlugin" "mupen64plus-video-n64"
     iniSet "AudioPlugin" "mupen64plus-audio-omx"
-    # Enable bilinear filtering for rice
-    # iniSet "Mipmapping" "2"
-    # iniSet "ForceTextureFilter" "2"
+
 
     mkRomDir "n64"
 

--- a/scriptmodules/libretrocores/lr-armsnes.sh
+++ b/scriptmodules/libretrocores/lr-armsnes.sh
@@ -1,6 +1,6 @@
 rp_module_id="lr-armsnes"
 rp_module_desc="SNES emu - forked from pocketsnes focused on performance"
-rp_module_menus="4+"
+rp_module_menus="2+"
 
 function sources_lr-armsnes() {
     gitPullOrClone "$md_build" git://github.com/rmaz/ARMSNES-libretro

--- a/scriptmodules/libretrocores/lr-catsfc.sh
+++ b/scriptmodules/libretrocores/lr-catsfc.sh
@@ -1,6 +1,6 @@
 rp_module_id="lr-catsfc"
 rp_module_desc="SNES emu - CATSFC based on Snes9x / NDSSFC / BAGSFC"
-rp_module_menus="4+"
+rp_module_menus="2+"
 
 function sources_lr-catsfc() {
     gitPullOrClone "$md_build" git://github.com/libretro/CATSFC-libretro.git

--- a/scriptmodules/libretrocores/lr-gpsp.sh
+++ b/scriptmodules/libretrocores/lr-gpsp.sh
@@ -1,6 +1,6 @@
 rp_module_id="lr-gpsp"
 rp_module_desc="GBA emu - gpSP port for libretro"
-rp_module_menus="4+"
+rp_module_menus="2+"
 rp_module_flags="!rpi1"
 
 function sources_lr-gpsp() {

--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -1,6 +1,6 @@
 rp_module_id="lr-nestopia"
 rp_module_desc="NES emu - Nestopia (enhanced) port for libretro"
-rp_module_menus="4+"
+rp_module_menus="2+"
 
 function sources_lr-nestopia() {
     gitPullOrClone "$md_build" https://github.com/libretro/nestopia.git

--- a/scriptmodules/libretrocores/lr-snes9x-next.sh
+++ b/scriptmodules/libretrocores/lr-snes9x-next.sh
@@ -1,6 +1,6 @@
 rp_module_id="lr-snes9x-next"
 rp_module_desc="SNES emulator - Snes9x 1.52+ (optimised) port for libretro"
-rp_module_menus="4+"
+rp_module_menus="2+"
 rp_module_flags="!rpi1"
 
 function sources_lr-snes9x-next() {


### PR DESCRIPTION
-Move nestopia, armsnes, snes9x-next, gpsp-libretro and catsfc to source based installations.
-Cleanup mupen64plus module
-Mupen64plus/Mupen64plus-testing: Use vfp optimized code id platform=rpi1