### PR TITLE
Usbromservice

### DIFF
--- a/scriptmodules/supplementary/usbromservice.sh
+++ b/scriptmodules/supplementary/usbromservice.sh
@@ -4,7 +4,7 @@ rp_module_menus="3+"
 rp_module_flags="nobin"
 
 function depends_usbromservice() {
-    getDepends usbmount
+    getDepends usbmount rsync
 }
 
 function enable_usbromservice() {

--- a/supplementary/01_retropie_copyroms
+++ b/supplementary/01_retropie_copyroms
@@ -9,12 +9,16 @@ user="USERTOBECHOSEN"
 home="$(eval echo ~$user)"
 retropie_path="$home/RetroPie"
 retropie_path_roms="$retropie_path/roms"
-retropie_path_emulationstation="$home/.emulationstation"
 
 usb_path="$UM_MOUNTPOINT/retropie"
 usb_path_roms="$usb_path/roms"
-usb_path_emulationstation_fromrpi="$usb_path/emulationstation/fromRPi"
-usb_path_emulationstation_torpi="$usb_path/emulationstation/toRPi"
+usb_path_from_rp="$usb_path/configs/from_retropie"
+usb_path_to_rp="$usb_path/configs/to_retropie"
+
+declare -A path_mapping
+
+# mapping from usb_path_to_rp/* to retropie location
+path_mapping["emulationstation"]="$home/.emulationstation"
 
 ## internals
 hook_name=${0##*/}
@@ -40,29 +44,36 @@ if [[ ! -d "$usb_path" ]]; then
     exit 0
 fi
 
-## main
+# make folders for syncing
+mkdir -p "$usb_path_roms" "$usb_path_from_rp" "$usb_path_to_rp"
+
 # mirror romdir structure to external drive
-if [[ ! -d "$usb_path_roms" ]]; then
-    log info "Attempting to create directory structure for ROMS in '$usb_path_roms' ..."
-    # fetch list of romdirs from current installation and mirror onto external driv
-    find "$retropie_path"/roms -mindepth 1 -maxdepth 1 -type d -printf "$usb_path_roms/%f\n" | xargs mkdir -p 2>/dev/null || true
-    exit 0
-fi
+log info "Attempting to create directory structure for ROMS in '$usb_path_roms' ..."
+# fetch list of romdirs from current installation and mirror onto external drive
+find "$retropie_path"/roms -mindepth 1 -maxdepth 1 -type d -printf "$usb_path_roms/%f\n" | xargs mkdir -p 2>/dev/null || true
 
-# make folders for config syncing
-mkdir -p "$usb_path_emulationstation_fromrpi" "$usb_path_emulationstation_torpi"
-
+log info "Syncing roms ..."
 # copy ROMs from USB stick to local SD card
-rsync -au --exclude '._*' --max-delete=-1 "$usb_path_roms/" "$retropie_path_roms/" >/dev/null 2>&1 || log err "rsync failed to sync ROMS, returned error code $?"
+rsync -rtu --exclude '._*' --max-delete=-1 "$usb_path_roms/" "$retropie_path_roms/" >/dev/null 2>&1 || log err "rsync failed to sync ROMS, returned error code $?"
+chown -R $user:$user "$retropie_path_roms"
 
-# copy EmulationStation configuration to USB stick 
-rsync -au --exclude '._*' --max-delete=-1 "$retropie_path_emulationstation/" "$usb_path_emulationstation_fromrpi/" >/dev/null 2>&1 || log err "rsync failed to sync EMULATIONSTATION configuration, returned error code $?"
+log info "Syncing configs ..."
+# copy configs to usb
+for to in "${!path_mapping[@]}"; do
+    from=${path_mapping[$to]}
+    rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$usb_path_from_rp/$to/" >/dev/null 2>&1 || log err "rsync failed to sync $from/ -> $usb_path_from_rp/$to/, returned error code $?"
+done
 
-# copy EmulationStation configuration from USB stick to local SD card
-rsync -au --exclude '._*' --max-delete=-1 "$usb_path_emulationstation_torpi/" "$retropie_path_emulationstation/" >/dev/null 2>&1 || log err "rsync failed to sync EMULATIONSTATION configuration, returned error code $?"
-
-# make sure that user can access the files
-chown -R $user:$user "$retropie_path" "$retropie_path_emulationstation"
+# copy configs from usb
+for from in $(find "$usb_path_to_rp/" -mindepth 1 -maxdepth 1); do
+    # basename
+    from_bn=${from##*/}
+    to=${path_mapping[$from_bn]}
+    if [[ -n "$to" ]]; then
+        rsync -rtu --exclude '._*' --max-delete=-1 "$from/" "$to/" >/dev/null 2>&1 || log err "rsync failed to sync $from/ -> $to/ configuration, returned error code $?"
+        chown -R $user:$user "$to"q
+    fi
+done
 
 # unmount USB stick
 umount "$UM_MOUNTPOINT"


### PR DESCRIPTION
 * always sync the roms folder - so latest rom folders are made available.
 * use an array to map retropie / usb configs
 * rsync without -a - just use -rt (recursive / preserve times). Avoids errors on fat32, and we will get away without preserving file permissions - files will be chowned to user when restored also