### PR TITLE
lowercase .32x

### DIFF
--- a/supplementary/platforms.cfg
+++ b/supplementary/platforms.cfg
@@ -43,7 +43,7 @@ nes_fullname="Nintendo Entertainment System"
 pcengine_exts=".pce .zip"
 pcengine_fullname="TurboGrafx 16 (PC Engine)"
 
-sega32x_exts=".32X .smd .bin .md .zip"
+sega32x_exts=".32x .smd .bin .md .zip"
 sega32x_fullname="Sega 32X"
 
 segacd_exts=".smd .bin .md .zip .iso"


### PR DESCRIPTION
This trivial change allows .32x and .32X files to be autodiscovered.