### PR TITLE
restart emulation station on exit (unless a key is pressed). Since emula...

### DIFF
--- a/scriptmodules/supplementary/emulationstation.sh
+++ b/scriptmodules/supplementary/emulationstation.sh
@@ -49,7 +49,12 @@ if [[ -n "\$(pidof X)" ]]; then
     exit 1
 fi
 
-\$es_bin "\$@"
+key=""
+while [[ -z "\$key" ]]; do
+    \$es_bin "\$@"
+    echo "EmulationStation will restart in 5 seconds. Press a key to exit back to console."
+    IFS= read -s -t 5 -N 1 key
+done
 _EOF_
     chmod +x /usr/bin/emulationstation
 


### PR DESCRIPTION
...tion station doesn't yet have a mechanism to pick up on

any changed roms, it is quite annoying for users to have to keep restarting / plug in a keyboard etc. With this change afetr 5 seconds
emulationstation will restart, unless a key is pressed and the user wants to drop to terminal.