### PR TITLE
Add some sixad optimizations

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -48,7 +48,8 @@ function install_ps3controller() {
     update-rc.d sixad defaults
 
 # If a bluetooth dongle is connected set state up and enable pscan
-    cat > $md_inst/bluetooth.sh << _EOF_  
+    cat > $md_inst/bluetooth.sh << _EOF_
+#!/bin/bash
 /usr/bin/hciconfig hci0 up
 if ! hciconfig | grep -q "BR/EDR"; then
     /usr/bin/hciconfig hci0 pscan
@@ -59,6 +60,7 @@ chmod +x "$md_inst/bluetooth.sh"
 
 # If a PS3 controller is connected over usb check if bluetooth dongle exits and start sixpair
     cat > $md_inst/ps3pair.sh << _EOF_  
+#!/bin/bash
 if ! hciconfig | grep -q "BR/EDR"; then
     /usr/bin/hciconfig hci0 pscan
     $md_inst/sixpair

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -51,8 +51,8 @@ function install_ps3controller() {
     cat > $md_inst/bluetooth.sh << _EOF_
 #!/bin/bash
 /usr/bin/hciconfig hci0 up
-if ! hciconfig | grep -q "BR/EDR"; then
-    /usr/bin/hciconfig hci0 pscan
+if hciconfig | grep -q "BR/EDR"; then
+    hciconfig hci0 pscan
 fi
 _EOF_
 
@@ -61,8 +61,8 @@ chmod +x "$md_inst/bluetooth.sh"
 # If a PS3 controller is connected over usb check if bluetooth dongle exits and start sixpair
     cat > $md_inst/ps3pair.sh << _EOF_  
 #!/bin/bash
-if ! hciconfig | grep -q "BR/EDR"; then
-    /usr/bin/hciconfig hci0 pscan
+if hciconfig | grep -q "BR/EDR"; then
+    hciconfig hci0 pscan
     $md_inst/sixpair
 fi
 _EOF_

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -75,11 +75,14 @@ chmod +x "$md_inst/ps3pair.sh"
 ACTION=="add", KERNEL=="hci0", RUN+="$md_inst/bluetooth.sh"
 _EOF_
 
-#udev rule for ps3 controller usb connection
+# udev rule for ps3 controller usb connection
     cat > /etc/udev/rules.d/99-sixpair.rules << _EOF_
 # Pair if PS3 controller is connected
 DRIVER=="usb", SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="0268", RUN+="$md_inst/ps3pair.sh"
 _EOF_
+
+# Start sixad daemon
+/etc/init.d/sixad start
 
     md_ret_files=(
         'sixpair'

--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -47,6 +47,38 @@ function install_ps3controller() {
     checkinstall -y --fstrans=no
     update-rc.d sixad defaults
 
+# If a bluetooth dongle is connected set state up and enable pscan
+    cat > $md_inst/bluetooth.sh << _EOF_  
+/usr/bin/hciconfig hci0 up
+if ! hciconfig | grep -q "BR/EDR"; then
+    /usr/bin/hciconfig hci0 pscan
+fi
+_EOF_
+
+chmod +x "$md_inst/bluetooth.sh"
+
+# If a PS3 controller is connected over usb check if bluetooth dongle exits and start sixpair
+    cat > $md_inst/ps3pair.sh << _EOF_  
+if ! hciconfig | grep -q "BR/EDR"; then
+    /usr/bin/hciconfig hci0 pscan
+    $md_inst/sixpair
+fi
+_EOF_
+
+chmod +x "$md_inst/ps3pair.sh"
+
+# udev rule for bluetooth dongle
+    cat > /etc/udev/rules.d/10-local.rules << _EOF_  
+# Set bluetooth power up
+ACTION=="add", KERNEL=="hci0", RUN+="$md_inst/bluetooth.sh"
+_EOF_
+
+#udev rule for ps3 controller usb connection
+    cat > /etc/udev/rules.d/99-sixpair.rules << _EOF_
+# Pair if PS3 controller is connected
+DRIVER=="usb", SUBSYSTEM=="usb", ATTR{idVendor}=="054c", ATTR{idProduct}=="0268", RUN+="$md_inst/ps3pair.sh"
+_EOF_
+
     md_ret_files=(
         'sixpair'
     )
@@ -57,6 +89,8 @@ function configure_ps3controller() {
     if ! hciconfig | grep -q "BR/EDR"; then
         printMsgs "dialog" "Cannot find the Bluetooth dongle. Please try to (re-)connect it and try again."
         break
+    else
+        hciconfig hci0 pscan
     fi
 
     printMsgs "dialog" "Please connect your PS3 controller via USB-CABLE and press ENTER."

--- a/scriptmodules/supplementary/ps3controllerpairing.sh
+++ b/scriptmodules/supplementary/ps3controllerpairing.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This file is part of RetroPie.
+# 
+# (c) Copyright 2012-2015  Florian Müller (contact@petrockblock.com)
+# 
+# See the LICENSE.md file at the top-level directory of this distribution and 
+# at https://raw.githubusercontent.com/petrockblog/RetroPie-Setup/master/LICENSE.md.
+#
+
+rp_module_id="ps3controllerpairing"
+rp_module_desc="Pair PS3 controller"
+rp_module_menus="3+"
+rp_module_flags="nobin"
+
+function configure_ps3controllerpairing() {
+    if [[ -f "$rootdir/supplementary/ps3controller/sixpair" ]]; then
+        # Only start sixpair. Don't waste time with driver compilation.
+        rp_callModule ps3controller configure
+    else
+        # Install PS3 controller driver
+        rp_callModule ps3controller	
+	  fi
+}


### PR DESCRIPTION
https://github.com/petrockblog/RetroPie-Setup/issues/654
-Add an own pairing module.
-Pair PS3 controller if controller is connected without retropie-setup. Use udev rules.
-Add hciconfig pscan to pair more than one controller.