### PR TITLE
Add some supported formats to platforms.cfg

### DIFF
--- a/supplementary/platforms.cfg
+++ b/supplementary/platforms.cfg
@@ -32,7 +32,7 @@ dreamcast_fullname="Dreamcast"
 fba_exts=".fba .zip"
 fba_fullname="Final Burn Alpha"
 
-gamegear_exts=".gg .zip"
+gamegear_exts=".gg .zip .bin"
 gamegear_fullname="Sega Gamegear"
 
 gba_exts=".gba .zip"
@@ -53,10 +53,10 @@ mame-advmame_exts=".zip"
 mame-mame4all_fullname="Multiple Arcade Machine Emulator"
 mame-mame4all_exts=".zip"
 
-mastersystem_exts=".sms .zip"
+mastersystem_exts=".sms .zip .bin"
 mastersystem_fullname="Sega Master System"
 
-megadrive_exts=".smd .bin .gen .md .zip"
+megadrive_exts=".smd .bin .gen .md .zip .sg"
 megadrive_fullname="Sega Mega Drive / Genesis"
 
 msx_exts=".rom .mx1 .mx2 .col .dsk .zip"
@@ -86,13 +86,13 @@ sega32x_fullname="Sega 32X"
 segacd_exts=".smd .bin .md .zip .iso"
 segacd_fullname="Sega Mega Drive / Genesis"
 
-sg-1000_exts=".sg .zip"
+sg-1000_exts=".sg .zip .bin"
 sg-1000_fullname="Sega SG-1000"
 
 saturn_exts=".iso .bin .zip"
 saturn_fullname="Sega Saturn"
 
-snes_exts=".smc .sfc .fig .swc .mgd .zip"
+snes_exts=".smc .sfc .fig .swc .mgd .zip .bin"
 snes_fullname="Super Nintendo"
 
 virtualboy_exts=".vb"


### PR DESCRIPTION
I have some roms with the .bin extension that work in the listed platforms. I tested with all emulators, for the respective platform.
I have also some .sg roms that i think they are Mega Drive roms, but not sure, could be SG-1000. They work with the 2 Mega Drive emulators so i added too.