### PR TITLE
Show controller number

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -93,7 +93,7 @@ enable_input 0
 enable_remote 0
 enable_rumble 1
 enable_timeout 0
-led_n_auto 0
+led_n_auto 1
 led_n_number 0
 led_anim 1
 enable_buttons 1


### PR DESCRIPTION
With led_n_auto set to 0, all controllers will show controller 1 LED, even if they are not the first controller.