### PR TITLE
fix rom path for limelight scripts

### DIFF
--- a/scriptmodules/supplementary/limelight.sh
+++ b/scriptmodules/supplementary/limelight.sh
@@ -112,7 +112,7 @@ _EOF_
     chmod +x "$romdir/limelight/"*.sh
 
     # Add System to es_system.cfg
-    setESSystem 'Limelight Game Streaming' 'limelight' '~/RetroPie/roms/ports' '.sh .SH' '%ROM%' 'pc' 'limelight'
+    setESSystem 'Limelight Game Streaming' 'limelight' '~/RetroPie/roms/limelight' '.sh .SH' '%ROM%' 'pc' 'limelight'
 
     echo -e "\nEverything done! Now reboot the Pi and you are all set \n"
 }


### PR DESCRIPTION
The limelight module installer pointed to the wrong rom directory and therefore could not find it's start scripts.