### PR TITLE
Add famicom disk system as an own system

### DIFF
--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -43,8 +43,11 @@ function configure_lr-nestopia() {
     rm -rf "$rootdir/$md_type/nestopia"
 
     mkRomDir "nes"
+    mkRomDir "fds"
     ensureSystemretroconfig "nes" "phosphor.glslp"
+	ensureSystemretroconfig "fds" "phosphor.glslp"
 
     delSystem "$md_id" "nes-nestopia"
     addSystem 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"
+    addSystem 1 "$md_id" "fds" "$md_inst/nestopia_libretro.so"
 }

--- a/scriptmodules/libretrocores/lr-nestopia.sh
+++ b/scriptmodules/libretrocores/lr-nestopia.sh
@@ -45,7 +45,7 @@ function configure_lr-nestopia() {
     mkRomDir "nes"
     mkRomDir "fds"
     ensureSystemretroconfig "nes" "phosphor.glslp"
-	ensureSystemretroconfig "fds" "phosphor.glslp"
+    ensureSystemretroconfig "fds" "phosphor.glslp"
 
     delSystem "$md_id" "nes-nestopia"
     addSystem 0 "$md_id" "nes" "$md_inst/nestopia_libretro.so"

--- a/supplementary/platforms.cfg
+++ b/supplementary/platforms.cfg
@@ -32,6 +32,9 @@ dreamcast_fullname="Dreamcast"
 fba_exts=".fba .zip"
 fba_fullname="Final Burn Alpha"
 
+fds_exts=".nes .fds .zip"
+fds_fullname="Famicom Disk System"
+
 gamegear_exts=".gg .zip .bin"
 gamegear_fullname="Sega Gamegear"
 


### PR DESCRIPTION
Because it is a own system like a SEGA CD or SEGA 32.
http://blog.petrockblock.com/forums/topic/specify-an-emulator-in-runcommand-sh/