### PR TITLE
-Removed hardcoded hciconfig binary location.  PS3 controller pairing on...

### DIFF
--- a/scriptmodules/supplementary/ps3controller.sh
+++ b/scriptmodules/supplementary/ps3controller.sh
@@ -54,7 +54,7 @@ function install_ps3controller() {
     # If a bluetooth dongle is connected set state up and enable pscan
     cat > "$md_inst/bluetooth.sh" << _EOF_
 #!/bin/bash
-/usr/bin/hciconfig hci0 up
+hciconfig hci0 up
 if hciconfig | grep -q "BR/EDR"; then
     hciconfig hci0 pscan
 fi


### PR DESCRIPTION
... my Pi2 RetroPie fails because my hciconfig binary is actually located in /usr/sbin/ and not /usr/bin.  This is far more compatible and safer; as well as used this way everywhere else in this script (this was probably an oversight).