### PR TITLE
-Updated reicast.sh installation script to pull from my latest branch…

### DIFF
--- a/scriptmodules/emulators/reicast.sh
+++ b/scriptmodules/emulators/reicast.sh
@@ -18,7 +18,7 @@ function depends_reicast() {
 }
 
 function sources_reicast() {
-    gitPullOrClone "$md_build" https://github.com/gizmo98/reicast-emulator.git skmp/rapi2-audiofix
+    gitPullOrClone "$md_build" https://github.com/free5ty1e/reicast-emulator.git free5ty1e/rpi2/retropie-reicast-updated
 }
 
 function build_reicast() {
@@ -40,13 +40,25 @@ function install_reicast() {
 function configure_reicast() {
     mkRomDir "dreamcast"
 
-    # create bios dir. Copy dc_boot.bin and dc_flash.bin there.
-    mkdir $md_inst/data
+    # Create home VMU, cfg, and data folders. Copy dc_boot.bin and dc_flash.bin to the ~/.reicast/data/ folder.
+    mkdir -p "$home/.reicast/data"
 
     cat > $md_inst/reicast.sh << _EOF_
 #!/bin/bash
-pushd $md_inst
-sudo aoss ./reicast.elf -config config:image="\$1"
+pushd "$md_inst"
+echo Reading the entire Reicast emulator into memory to execute from there...
+sudo mkdir tmpfs
+#TODO: Find optimal smaller tmpfs size, I do not believe anywhere near this much is required.  I have only ever seen 54MB utilized during a game of Rush 2049.
+sudo mount -o size=450M -t tmpfs none tmpfs/
+sudo cp -v * tmpfs/
+cd tmpfs
+sudo aoss ./reicast.elf -config config:homedir="$home" -config config:image="$1"
+cd ..
+echo Ensuring any freshly-created VMUs are owned by pi and not root...
+sudo chown -R pi:pi "$home/.reicast"
+echo Freeing up memory...
+sudo umount "$md_inst/tmpfs"
+sudo rm -rf tmpfs
 popd
 _EOF_
 
@@ -54,4 +66,7 @@ _EOF_
     
     # add system
     addSystem 1 "$md_id" "dreamcast" "$md_inst/reicast.sh %ROM%"
+
+    __INFMSGS+=("You need to copy the Dreamcast BIOS files (dc_boot.bin and dc_flash.bin) to the folder $home/.reicast/data/ to boot the Dreamcast emulator.")
+
 }


### PR DESCRIPTION
…, which has been rebased from the latest upstream master and has additional improvements and features: (see post here for details: http://blog.petrockblock.com/forums/topic/configuring-controllers-in-reicast/page/2/#post-99514 )

* Launch script now runs emulator and the fallback file allocation for rpi2 from tmpfs in memory instead of performing lengthy SD writes mid-emulation (which was causing long freezes in gameplay and general overall slowdown)
* Controller mapping via emu.cfg is now a reality, individually for different controllers for different players
* Basic multiplayer is now implemented!
* 8 VMUs are now connected!
* VMUs and emu.cfg and BIOS files now all reside in home folder /home/pi/.reicast and .reicast/data/ for the BIOS files
* More improvements but I forget ATM